### PR TITLE
fix incorrect rendering of array of objects with no type [STU-362]

### DIFF
--- a/src/utils/renderSchema.ts
+++ b/src/utils/renderSchema.ts
@@ -77,7 +77,12 @@ export const renderSchema: Walker = function*(schema, level = 0, meta = { path: 
         ...meta,
         ...(parsedSchema.items !== undefined &&
           !Array.isArray(parsedSchema.items) && {
-            subtype: '$ref' in parsedSchema.items ? `$ref( ${parsedSchema.items.$ref} )` : parsedSchema.items.type,
+            subtype:
+              '$ref' in parsedSchema.items
+                ? `$ref( ${parsedSchema.items.$ref} )`
+                : parsedSchema.items.type ||
+                  (parsedSchema.items.properties && 'object') ||
+                  (parsedSchema.items.items && 'array'),
           }),
         path,
       },


### PR DESCRIPTION
Related to [STU-362](https://stoplightio.atlassian.net/browse/STU-362)

Changes:
- fix issue causing not rendering schema if object node does not have a type specified

Context:
Issue appeared only for arrays that contained objects without specified type. This way node subtype property was undefined and the process of node children rendering stopped.  

Before:
![Screenshot from 2019-07-12 12-57-08](https://user-images.githubusercontent.com/14196079/61123439-a157fa00-a4a4-11e9-911a-1bf885c8605c.png)

After:
![Screenshot from 2019-07-12 12-55-59](https://user-images.githubusercontent.com/14196079/61123444-a4eb8100-a4a4-11e9-9e4b-07d56025075b.png)
