### PR TITLE
refactor: pass nodes to rowRendererRight

### DIFF
--- a/src/components/SchemaRow.tsx
+++ b/src/components/SchemaRow.tsx
@@ -8,15 +8,16 @@ import get = require('lodash/get');
 import map = require('lodash/map');
 import size = require('lodash/size');
 
-import { GoToRefHandler, IExtendableRenderers, SchemaNodeWithMeta, SchemaTreeListNode } from '../types';
+import { GoToRefHandler, SchemaNodeWithMeta, SchemaTreeListNode } from '../types';
 import { isCombiner, isRef } from '../utils';
 import { Types } from './';
 
-export interface ISchemaRow extends IExtendableRenderers {
+export interface ISchemaRow {
   node: SchemaTreeListNode;
   rowOptions: IRowRendererOptions;
   onGoToRef?: GoToRefHandler;
   toggleExpand: () => void;
+  rowRendererRight?: (node: SchemaTreeListNode) => React.ReactElement;
 }
 
 const ICON_SIZE = 12;

--- a/src/components/SchemaTree.tsx
+++ b/src/components/SchemaTree.tsx
@@ -50,7 +50,9 @@ export const SchemaTree = observer<ISchemaTree>(props => {
               toggleExpand={() => {
                 treeStore.toggleExpand(node);
               }}
-              rowRendererRight={props.rowRendererRight}
+              rowRendererRight={
+                props.rowRendererRight && props.rowRendererRight.bind({}, treeStore.nodes as SchemaTreeListNode[])
+              }
               node={node as SchemaTreeListNode}
               rowOptions={rowOptions}
               {...itemData}

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,7 @@ import { Dictionary, JsonPath } from '@stoplight/types';
 import { JSONSchema4, JSONSchema4TypeName } from 'json-schema';
 
 export interface IExtendableRenderers {
-  rowRendererRight?: (node: SchemaTreeListNode) => React.ReactElement;
+  rowRendererRight?: (nodes: SchemaTreeListNode[], node: SchemaTreeListNode) => React.ReactElement;
   schemaControlsRenderer?: () => React.ReactElement;
 }
 


### PR DESCRIPTION
This gives more control to `rowRendererRight`. Thanks to this change, it is now possible to compare the current node with the rest of the nodes that JSV has access to.