### PR TITLE
fix: combiners inside of arrays

### DIFF
--- a/src/__fixtures__/array-of-allofs.json
+++ b/src/__fixtures__/array-of-allofs.json
@@ -1,0 +1,28 @@
+{
+  "title": "Test",
+  "type": "object",
+  "properties": {
+    "array-all-objects": {
+      "type": "array",
+      "items": {
+        "allOf": [
+          {
+            "properties": {
+              "foo": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "properties": {
+              "bar": {
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "type": "object"
+      }
+    }
+  }
+}

--- a/src/components/shared/Property.tsx
+++ b/src/components/shared/Property.tsx
@@ -2,8 +2,7 @@ import { size as _size } from 'lodash-es';
 import * as React from 'react';
 import { GoToRefHandler, IArrayNode, IObjectNode, SchemaKind, SchemaNodeWithMeta } from '../../types';
 import { inferType } from '../../utils/inferType';
-import { isCombiner } from '../../utils/isCombiner';
-import { isRef } from '../../utils/isRef';
+import { isCombinerNode, isRefNode } from '../../utils/nodes';
 import { Types } from './Types';
 
 export interface IProperty {
@@ -12,7 +11,7 @@ export interface IProperty {
 }
 
 export const Property: React.FunctionComponent<IProperty> = ({ node, onGoToRef }) => {
-  const type = isRef(node) ? '$ref' : isCombiner(node) ? node.combiner : node.type;
+  const type = isRefNode(node) ? '$ref' : isCombinerNode(node) ? node.combiner : node.type;
   const subtype =
     type === SchemaKind.Array && (node as IArrayNode).items !== undefined
       ? inferType((node as IArrayNode).items!)

--- a/src/utils/__tests__/__snapshots__/renderSchema.spec.ts.snap
+++ b/src/utils/__tests__/__snapshots__/renderSchema.spec.ts.snap
@@ -1,5 +1,234 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`renderSchema util should match array-of-allofs.json 1`] = `
+Array [
+  Object {
+    "canHaveChildren": true,
+    "id": "random-id",
+    "level": 0,
+    "metadata": Object {
+      "additionalProperties": undefined,
+      "annotations": Object {
+        "title": "Test",
+      },
+      "enum": undefined,
+      "id": "random-id",
+      "path": Array [],
+      "patternProperties": undefined,
+      "properties": Object {
+        "array-all-objects": Object {
+          "items": Object {
+            "allOf": Array [
+              Object {
+                "properties": Object {
+                  "foo": Object {
+                    "type": "string",
+                  },
+                },
+                "type": "object",
+              },
+              Object {
+                "properties": Object {
+                  "bar": Object {
+                    "type": "string",
+                  },
+                },
+                "type": "object",
+              },
+            ],
+            "type": "object",
+          },
+          "type": "array",
+        },
+      },
+      "type": "object",
+      "validations": Object {},
+    },
+    "name": "",
+  },
+  Object {
+    "canHaveChildren": true,
+    "id": "random-id",
+    "level": 1,
+    "metadata": Object {
+      "additionalItems": undefined,
+      "annotations": Object {},
+      "enum": undefined,
+      "id": "random-id",
+      "items": Object {
+        "allOf": Array [
+          Object {
+            "properties": Object {
+              "foo": Object {
+                "type": "string",
+              },
+            },
+            "type": "object",
+          },
+          Object {
+            "properties": Object {
+              "bar": Object {
+                "type": "string",
+              },
+            },
+            "type": "object",
+          },
+        ],
+        "type": "object",
+      },
+      "name": "array-all-objects",
+      "path": Array [
+        "properties",
+        "array-all-objects",
+      ],
+      "required": false,
+      "subtype": "allOf",
+      "type": "array",
+      "validations": Object {},
+    },
+    "name": "",
+  },
+  Object {
+    "canHaveChildren": true,
+    "id": "random-id",
+    "level": 2,
+    "metadata": Object {
+      "annotations": Object {},
+      "combiner": "allOf",
+      "id": "random-id",
+      "name": "array-all-objects",
+      "path": Array [
+        "properties",
+        "array-all-objects",
+        "items",
+      ],
+      "properties": Array [
+        Object {
+          "properties": Object {
+            "foo": Object {
+              "type": "string",
+            },
+          },
+          "type": "object",
+        },
+        Object {
+          "properties": Object {
+            "bar": Object {
+              "type": "string",
+            },
+          },
+          "type": "object",
+        },
+      ],
+      "required": false,
+      "type": "object",
+    },
+    "name": "",
+  },
+  Object {
+    "canHaveChildren": true,
+    "id": "random-id",
+    "level": 3,
+    "metadata": Object {
+      "additionalProperties": undefined,
+      "annotations": Object {},
+      "enum": undefined,
+      "id": "random-id",
+      "path": Array [
+        "properties",
+        "array-all-objects",
+        "items",
+        "allOf",
+        0,
+      ],
+      "patternProperties": undefined,
+      "properties": Object {
+        "foo": Object {
+          "type": "string",
+        },
+      },
+      "type": "object",
+      "validations": Object {},
+    },
+    "name": "",
+  },
+  Object {
+    "id": "random-id",
+    "level": 4,
+    "metadata": Object {
+      "annotations": Object {},
+      "enum": undefined,
+      "id": "random-id",
+      "name": "foo",
+      "path": Array [
+        "properties",
+        "array-all-objects",
+        "items",
+        "allOf",
+        0,
+        "properties",
+        "foo",
+      ],
+      "required": false,
+      "type": "string",
+      "validations": Object {},
+    },
+    "name": "",
+  },
+  Object {
+    "canHaveChildren": true,
+    "id": "random-id",
+    "level": 3,
+    "metadata": Object {
+      "additionalProperties": undefined,
+      "annotations": Object {},
+      "divider": "and",
+      "enum": undefined,
+      "id": "random-id",
+      "path": Array [
+        "properties",
+        "array-all-objects",
+        "items",
+        "allOf",
+        1,
+      ],
+      "patternProperties": undefined,
+      "properties": Object {
+        "bar": Object {
+          "type": "string",
+        },
+      },
+      "type": "object",
+      "validations": Object {},
+    },
+    "name": "",
+  },
+  Object {
+    "id": "random-id",
+    "level": 4,
+    "metadata": Object {
+      "annotations": Object {},
+      "enum": undefined,
+      "id": "random-id",
+      "name": "bar",
+      "path": Array [
+        "properties",
+        "array-all-objects",
+        "items",
+        "allOf",
+        1,
+        "properties",
+        "bar",
+      ],
+      "required": false,
+      "type": "string",
+      "validations": Object {},
+    },
+    "name": "",
+  },
+]
+`;
+
 exports[`renderSchema util should match array-of-objects.json 1`] = `
 Array [
   Object {

--- a/src/utils/__tests__/isCombiner.spec.ts
+++ b/src/utils/__tests__/isCombiner.spec.ts
@@ -1,12 +1,12 @@
-import { isCombiner } from '../isCombiner';
+import { isCombinerNode } from '../nodes';
 
-describe('isCombiner function', () => {
+describe('isCombinerNode function', () => {
   test('should return false if object without combiner is given', () => {
-    expect(isCombiner({} as any)).toBe(false);
-    expect(isCombiner({ properties: [] } as any)).toBe(false);
+    expect(isCombinerNode({} as any)).toBe(false);
+    expect(isCombinerNode({ properties: [] } as any)).toBe(false);
   });
 
   test.each(['allOf', 'anyOf', 'oneOf'])('should return true if object with %s is given', combiner => {
-    expect(isCombiner({ combiner } as any)).toBe(true);
+    expect(isCombinerNode({ combiner } as any)).toBe(true);
   });
 });

--- a/src/utils/__tests__/renderSchema.spec.ts
+++ b/src/utils/__tests__/renderSchema.spec.ts
@@ -15,6 +15,7 @@ describe('renderSchema util', () => {
     ['combiner-schema.json', ''],
     ['array-of-objects.json', ''],
     ['array-of-refs.json', ''],
+    ['array-of-allofs.json', ''],
     ['tickets.schema.json', ''],
   ])('should match %s', (schema, dereferenced) => {
     expect(

--- a/src/utils/getArraySubtype.ts
+++ b/src/utils/getArraySubtype.ts
@@ -1,0 +1,21 @@
+import { JSONSchema4TypeName } from 'json-schema';
+import { IArrayNode, JSONSchema4CombinerName } from '../types';
+import { getCombiner } from './getCombiner';
+import { inferType } from './inferType';
+
+export function getArraySubtype(
+  node: IArrayNode,
+): JSONSchema4TypeName | JSONSchema4TypeName[] | JSONSchema4CombinerName | string | undefined {
+  if (!node.items || Array.isArray(node.items)) return;
+  if ('$ref' in node.items) {
+    return `$ref( ${node.items.$ref} )`;
+  }
+
+  const combiner = getCombiner(node.items);
+
+  if (combiner !== undefined) {
+    return combiner;
+  }
+
+  return inferType(node.items);
+}

--- a/src/utils/getCombiner.ts
+++ b/src/utils/getCombiner.ts
@@ -1,0 +1,8 @@
+import { JSONSchema4 } from 'json-schema';
+import { JSONSchema4CombinerName } from '../types';
+
+export const getCombiner = (node: JSONSchema4): JSONSchema4CombinerName | void => {
+  if ('allOf' in node) return 'allOf';
+  if ('anyOf' in node) return 'anyOf';
+  if ('oneOf' in node) return 'oneOf';
+};

--- a/src/utils/isCombiner.ts
+++ b/src/utils/isCombiner.ts
@@ -1,3 +1,5 @@
-import { ICombinerNode, SchemaNode } from '../types';
+import { JSONSchema4CombinerName } from '../types';
 
-export const isCombiner = (node: SchemaNode): node is ICombinerNode => 'combiner' in node;
+const combinerTypes = ['allOf', 'oneOf', 'anyOf'];
+
+export const isCombiner = (type: string): type is JSONSchema4CombinerName => combinerTypes.includes(type);

--- a/src/utils/isRef.ts
+++ b/src/utils/isRef.ts
@@ -1,3 +1,0 @@
-import { IRefNode, SchemaNode } from '../types';
-
-export const isRef = (node: SchemaNode): node is IRefNode => '$ref' in node;

--- a/src/utils/isSchemaViewerEmpty.ts
+++ b/src/utils/isSchemaViewerEmpty.ts
@@ -1,12 +1,11 @@
 import { get as _get, isEmpty as _isEmpty } from 'lodash-es';
-
-const combinerTypes = ['allOf', 'oneOf', 'anyOf'];
+import { isCombiner } from './isCombiner';
 
 export const isSchemaViewerEmpty = (schema: unknown) => {
   if (typeof schema !== 'object' || schema === null) return true;
 
   const objectKeys = Object.keys(schema);
-  if (objectKeys.length === 1 && combinerTypes.includes(objectKeys[0])) {
+  if (objectKeys.length === 1 && isCombiner(objectKeys[0])) {
     return _isEmpty(_get(schema, objectKeys[0], []));
   }
 

--- a/src/utils/nodes.ts
+++ b/src/utils/nodes.ts
@@ -1,0 +1,5 @@
+import { ICombinerNode, IRefNode, SchemaNode } from '../types';
+
+export const isRefNode = (node: SchemaNode): node is IRefNode => '$ref' in node;
+
+export const isCombinerNode = (node: SchemaNode): node is ICombinerNode => 'combiner' in node;

--- a/src/utils/walk.ts
+++ b/src/utils/walk.ts
@@ -5,7 +5,6 @@ import {
   ICombinerNode,
   IObjectNode,
   IRefNode,
-  JSONSchema4CombinerName,
   SchemaKind,
   SchemaNode,
 } from '../types';
@@ -14,12 +13,7 @@ import { getAnnotations } from './getAnnotations';
 import { getPrimaryType } from './getPrimaryType';
 import { getValidations } from './getValidations';
 import { inferType } from './inferType';
-
-const getCombiner = (node: JSONSchema4): JSONSchema4CombinerName | void => {
-  if ('allOf' in node) return 'allOf';
-  if ('anyOf' in node) return 'anyOf';
-  if ('oneOf' in node) return 'oneOf';
-};
+import { getCombiner } from './getCombiner';
 
 function assignNodeSpecificFields(base: IBaseNode, node: JSONSchema4) {
   switch (getPrimaryType(node)) {


### PR DESCRIPTION
Fixes https://github.com/stoplightio/json-schema-viewer/issues/50 and perhaps https://github.com/stoplightio/json-schema-viewer/issues/44

![image](https://user-images.githubusercontent.com/9273484/64528980-13fd1e80-d30a-11e9-93da-62da03bd9b21.png)
![image](https://user-images.githubusercontent.com/9273484/64529000-1cedf000-d30a-11e9-8f82-0a435a05078b.png)

Side note,
I need to make heavier use of tagged union types, so that we don't need to to these `as Something` explicit type assertions. This will result in much cleaner code - will do it at some point.