### PR TITLE
fix: do not mutate combiner child

### DIFF
--- a/src/utils/__tests__/__snapshots__/renderSchema.spec.ts.snap
+++ b/src/utils/__tests__/__snapshots__/renderSchema.spec.ts.snap
@@ -25,7 +25,6 @@ Array [
                     "type": "string",
                   },
                 },
-                "type": "object",
               },
               Object {
                 "properties": Object {
@@ -33,7 +32,6 @@ Array [
                     "type": "string",
                   },
                 },
-                "type": "object",
               },
             ],
             "type": "object",
@@ -63,7 +61,6 @@ Array [
                 "type": "string",
               },
             },
-            "type": "object",
           },
           Object {
             "properties": Object {
@@ -71,7 +68,6 @@ Array [
                 "type": "string",
               },
             },
-            "type": "object",
           },
         ],
         "type": "object",

--- a/src/utils/__tests__/renderSchema.spec.ts
+++ b/src/utils/__tests__/renderSchema.spec.ts
@@ -10,16 +10,33 @@ jest.mock('../generateId', () => ({
 
 describe('renderSchema util', () => {
   it.each([
-    ['default-schema.json', ''],
-    ['ref/original.json', 'ref/resolved.json'],
-    ['combiner-schema.json', ''],
-    ['array-of-objects.json', ''],
-    ['array-of-refs.json', ''],
-    ['array-of-allofs.json', ''],
-    ['tickets.schema.json', ''],
-  ])('should match %s', (schema, dereferenced) => {
+    'default-schema.json',
+    'ref/original.json',
+    'combiner-schema.json',
+    'array-of-objects.json',
+    'array-of-refs.json',
+    'array-of-allofs.json',
+    'tickets.schema.json',
+  ])('should match %s', schema => {
     expect(
-      Array.from(renderSchema(JSON.parse(fs.readFileSync(path.resolve(BASE_PATH, schema), 'utf-8')))),
+      Array.from(renderSchema(JSON.parse(fs.readFileSync(path.resolve(BASE_PATH, schema), 'utf8')))),
     ).toMatchSnapshot();
+  });
+
+  it.each([
+    'default-schema.json',
+    'ref/original.json',
+    'combiner-schema.json',
+    'array-of-objects.json',
+    'array-of-refs.json',
+    'array-of-allofs.json',
+    'tickets.schema.json',
+  ])('should not mutate original object %s', schema => {
+    const content = fs.readFileSync(path.resolve(BASE_PATH, schema), 'utf8');
+    const input = JSON.parse(content);
+
+    Array.from(renderSchema(input));
+
+    expect(input).toStrictEqual(JSON.parse(content));
   });
 });

--- a/src/utils/renderSchema.ts
+++ b/src/utils/renderSchema.ts
@@ -104,10 +104,13 @@ export const renderSchema: Walker = function*(schema, level = 0, meta = { path: 
       if (node.properties !== undefined) {
         for (const [i, property] of node.properties.entries()) {
           if ('type' in node) {
-            property.type = property.type || node.type;
+            node.properties[i] = {
+              ...property,
+              type: property.type || node.type,
+            };
           }
 
-          yield* renderSchema(property, level + 1, {
+          yield* renderSchema(node.properties[i], level + 1, {
             ...(i !== 0 && { divider: DIVIDERS[node.combiner] }),
             path: [...path, node.combiner, i],
           });

--- a/src/utils/walk.ts
+++ b/src/utils/walk.ts
@@ -34,10 +34,11 @@ function processNode(node: JSONSchema4): SchemaNode | void {
   const type = node.type || inferType(node);
 
   if (combiner) {
+    const properties = node[combiner];
     return {
       id: generateId(),
       combiner,
-      properties: node[combiner],
+      properties: Array.isArray(properties) ? properties.slice() : properties,
       annotations: getAnnotations(node),
       ...(type !== undefined && { type }),
     } as ICombinerNode;


### PR DESCRIPTION
Fixes https://github.com/stoplightio/json-schema-viewer/issues/58
A note on snapshot change - it shouldn't have any impact, since the actual node that gets rendered in tree-list has a proper type assigned - see [line 146](https://github.com/stoplightio/json-schema-viewer/blob/b186ec373f0b3f00184f4171ce3412b4b5987cb2/src/utils/__tests__/__snapshots__/renderSchema.spec.ts.snap#L146) and [line 197](https://github.com/stoplightio/json-schema-viewer/blob/b186ec373f0b3f00184f4171ce3412b4b5987cb2/src/utils/__tests__/__snapshots__/renderSchema.spec.ts.snap#L197).
It's just that the other nodes point at original object.

You can also verify it manually in storybook by pasting the schema file and comparing the view. :P

This got me realize we actually seem to squeeze too much into metadata. It seems like we could make it much leaner.