### PR TITLE
fix: don’t kill entire JSV for one null value

### DIFF
--- a/src/utils/renderSchema.ts
+++ b/src/utils/renderSchema.ts
@@ -48,7 +48,6 @@ const getPatternProperties: Walker = function*(schema, level = 0, meta) {
 export const renderSchema: Walker = function*(schema, level = 0, meta = { path: [] }, options = {}) {
   if (typeof schema !== 'object' || schema === null) {
     const error = `Expected schema to be an "object" but received ${schema === null ? '"null"' : `a "${typeof schema}"`} at path ${JSON.stringify(meta.path)}`;
-    console.warn(error);
     return;
   }
 

--- a/src/utils/renderSchema.ts
+++ b/src/utils/renderSchema.ts
@@ -47,9 +47,9 @@ const getPatternProperties: Walker = function*(schema, level = 0, meta) {
 
 export const renderSchema: Walker = function*(schema, level = 0, meta = { path: [] }, options = {}) {
   if (typeof schema !== 'object' || schema === null) {
-    throw new TypeError(
-      `Expected schema to be an "object" but received ${schema === null ? '"null"' : `a "${typeof schema}"`}`,
-    );
+    const error = `Expected schema to be an "object" but received ${schema === null ? '"null"' : `a "${typeof schema}"`} at path ${JSON.stringify(meta.path)}`;
+    console.warn(error);
+    return;
   }
 
   if (options.depth !== undefined && level >= options.depth) return;

--- a/src/utils/renderSchema.ts
+++ b/src/utils/renderSchema.ts
@@ -47,7 +47,6 @@ const getPatternProperties: Walker = function*(schema, level = 0, meta) {
 
 export const renderSchema: Walker = function*(schema, level = 0, meta = { path: [] }, options = {}) {
   if (typeof schema !== 'object' || schema === null) {
-    const error = `Expected schema to be an "object" but received ${schema === null ? '"null"' : `a "${typeof schema}"`} at path ${JSON.stringify(meta.path)}`;
     return;
   }
 


### PR DESCRIPTION
Open to suggestions on better alternative. Current behavior is no good - if there is a `null` value the entire component doesn't work.

@P0lip thoughts?