### PR TITLE
Fix: safe stringify

### DIFF
--- a/src/components/shared/Validations.tsx
+++ b/src/components/shared/Validations.tsx
@@ -1,3 +1,4 @@
+import { safeStringify } from '@stoplight/json';
 import { Dictionary } from '@stoplight/types';
 import { Popover } from '@stoplight/ui-kit';
 import cn from 'classnames';
@@ -50,7 +51,7 @@ export const Validations: React.FunctionComponent<IValidations> = ({
                 } else {
                   elem = (
                     <div className="m-1 px-1 bg-gray-2 dark:bg-gray-8 font-bold text-sm rounded" key={index}>
-                      {typeof validation === 'string' ? `"${validation}"` : String(validation)}
+                      {typeof validation === 'string' ? `"${validation}"` : safeStringify(validation)}
                     </div>
                   );
                 }

--- a/src/components/shared/Validations.tsx
+++ b/src/components/shared/Validations.tsx
@@ -1,4 +1,3 @@
-import { safeStringify } from '@stoplight/json';
 import { Dictionary } from '@stoplight/types';
 import { Popover } from '@stoplight/ui-kit';
 import cn from 'classnames';
@@ -51,7 +50,7 @@ export const Validations: React.FunctionComponent<IValidations> = ({
                 } else {
                   elem = (
                     <div className="m-1 px-1 bg-gray-2 dark:bg-gray-8 font-bold text-sm rounded" key={index}>
-                      {safeStringify(validation)}
+                      {typeof validation === 'string' ? `"${validation}"` : String(validation)}
                     </div>
                   );
                 }

--- a/src/components/shared/Validations.tsx
+++ b/src/components/shared/Validations.tsx
@@ -1,3 +1,4 @@
+import { safeStringify } from '@stoplight/json';
 import { Dictionary } from '@stoplight/types';
 import { Popover } from '@stoplight/ui-kit';
 import cn from 'classnames';
@@ -50,7 +51,7 @@ export const Validations: React.FunctionComponent<IValidations> = ({
                 } else {
                   elem = (
                     <div className="m-1 px-1 bg-gray-2 dark:bg-gray-8 font-bold text-sm rounded" key={index}>
-                      {JSON.stringify(validation)}
+                      {safeStringify(validation)}
                     </div>
                   );
                 }


### PR DESCRIPTION
Now as `BigInt` numbers may be used we need to stringify them safely.
Though in case of validations we don't need to use stringify as we check for arrays and objects before. Unless there are other possible types that won't work well with `String()`). Are there @P0lip ?
We could just use `safeStringify` but then we won't get wrapping quotes for strings and would need to check for type anyway.