### PR TITLE
fix: eager resolving errors

### DIFF
--- a/src/tree/__tests__/tree.spec.ts
+++ b/src/tree/__tests__/tree.spec.ts
@@ -1131,6 +1131,35 @@ describe('SchemaTree', () => {
         "
       `);
     });
+
+    test('should handle resolving errors', () => {
+      const schema: JSONSchema4 = {
+        type: 'object',
+        properties: {
+          foo: {
+            type: 'string',
+          },
+          bar: {
+            $ref: 'http://localhost:8080/some/not/existing/path',
+          },
+        },
+      };
+
+      const tree = new SchemaTree(schema, new SchemaTreeState(), {
+        expandedDepth: Infinity,
+        mergeAllOf: true,
+        resolveRef: () => {
+          throw new Error('resolving error');
+        },
+        shouldResolveEagerly: true,
+        onPopulate: void 0,
+      });
+
+      tree.populate();
+
+      expect(tree.count).toEqual(4);
+      expect(getNodeMetadata(tree.itemAt(3)!)).toHaveProperty('error', 'resolving error');
+    });
   });
 
   describe('onPopulate handler', () => {

--- a/src/tree/utils/walk.ts
+++ b/src/tree/utils/walk.ts
@@ -29,7 +29,7 @@ function assignNodeSpecificFields(base: IBaseNode, node: JSONSchema4) {
   }
 }
 
-function processNode(node: JSONSchema4): SchemaNode | void {
+export function processNode(node: JSONSchema4): SchemaNode {
   const combiner = getCombiner(node);
   const type = node.type || inferType(node);
   const title = typeof node.title === 'string' ? { title: node.title } : null;


### PR DESCRIPTION
Related to https://github.com/stoplightio/platform-internal/issues/3007

Resolving function may throw error which should be handled when resolving schema eagerly. 
Instead of replacing all children from parent node with an error one it should add proper child containing that error node.

**Before**:
![Peek 2020-07-01 14-28](https://user-images.githubusercontent.com/14196079/86243777-3cab1900-bba7-11ea-818c-af879ce57a67.gif)

**After**:
![Peek 2020-07-01 14-29](https://user-images.githubusercontent.com/14196079/86243784-3f0d7300-bba7-11ea-8a1a-231c49d5a4a6.gif)
