### PR TITLE
feat: conditionaly render readOnly writeOnly nodes

### DIFF
--- a/src/__fixtures__/default-schema.json
+++ b/src/__fixtures__/default-schema.json
@@ -12,11 +12,13 @@
       "maximum": 150,
       "multipleOf": 10,
       "exclusiveMinimum": true,
-      "exclusiveMaximum": true
+      "exclusiveMaximum": true,
+      "readOnly": true
     },
     "completed_at": {
       "type": "string",
-      "format": "date-time"
+      "format": "date-time",
+      "writeOnly": true
     },
     "items": {
       "type": ["null", "array"],

--- a/src/__stories__/JsonSchemaViewer.tsx
+++ b/src/__stories__/JsonSchemaViewer.tsx
@@ -24,8 +24,8 @@ storiesOf('JsonSchemaViewer', module)
       hideTopBar={boolean('hideTopBar', false)}
       shouldResolveEagerly={boolean('shouldResolveEagerly', false)}
       onGoToRef={action('onGoToRef')}
-      context={select(
-        'context',
+      viewMode={select(
+        'viewMode',
         {
           standalone: 'standalone',
           read: 'read',

--- a/src/__stories__/JsonSchemaViewer.tsx
+++ b/src/__stories__/JsonSchemaViewer.tsx
@@ -24,6 +24,15 @@ storiesOf('JsonSchemaViewer', module)
       hideTopBar={boolean('hideTopBar', false)}
       shouldResolveEagerly={boolean('shouldResolveEagerly', false)}
       onGoToRef={action('onGoToRef')}
+      context={select(
+        'context',
+        {
+          standalone: 'standalone',
+          read: 'read',
+          write: 'write',
+        },
+        'standalone',
+      )}
     />
   ))
   .add('custom schema', () => (

--- a/src/components/JsonSchemaViewer.tsx
+++ b/src/components/JsonSchemaViewer.tsx
@@ -101,16 +101,12 @@ export class JsonSchemaViewerComponent extends React.PureComponent<IJsonSchemaVi
       this.treeStore.defaultExpandedDepth !== this.expandedDepth ||
       prevProps.schema !== this.props.schema ||
       prevProps.mergeAllOf !== this.props.mergeAllOf ||
-      prevProps.shouldResolveEagerly !== this.props.shouldResolveEagerly
+      prevProps.shouldResolveEagerly !== this.props.shouldResolveEagerly ||
+      prevProps.context !== this.props.context
     ) {
       this.treeStore.defaultExpandedDepth = this.expandedDepth;
       this.tree.treeOptions = this.treeOptions;
       this.tree.schema = this.props.schema;
-      this.renderSchema();
-    }
-
-    if (prevProps.context !== this.props.context) {
-      this.tree.treeOptions.context = this.props.context ?? 'standalone';
       this.renderSchema();
     }
   }

--- a/src/components/JsonSchemaViewer.tsx
+++ b/src/components/JsonSchemaViewer.tsx
@@ -6,7 +6,7 @@ import * as React from 'react';
 
 import { JSONSchema4 } from 'json-schema';
 import { SchemaTree, SchemaTreeOptions, SchemaTreePopulateHandler, SchemaTreeRefDereferenceFn } from '../tree/tree';
-import { GoToRefHandler, RowRenderer, ViewContext } from '../types';
+import { GoToRefHandler, RowRenderer, ViewMode } from '../types';
 import { isSchemaViewerEmpty } from '../utils/isSchemaViewerEmpty';
 import { SchemaTree as SchemaTreeComponent } from './SchemaTree';
 
@@ -27,11 +27,11 @@ export interface IJsonSchemaViewer {
   onTreePopulate?: SchemaTreePopulateHandler;
   resolveRef?: SchemaTreeRefDereferenceFn;
   shouldResolveEagerly?: boolean;
-  context?: ViewContext;
+  viewMode?: ViewMode;
 }
 
-export const Context = React.createContext<ViewContext>('standalone');
-Context.displayName = 'ViewContext';
+export const ViewModeContext = React.createContext<ViewMode>('standalone');
+ViewModeContext.displayName = 'ViewModeContext';
 
 export class JsonSchemaViewerComponent extends React.PureComponent<IJsonSchemaViewer & ErrorBoundaryForwardedProps> {
   protected readonly treeStore: TreeStore;
@@ -55,7 +55,7 @@ export class JsonSchemaViewerComponent extends React.PureComponent<IJsonSchemaVi
       resolveRef: this.props.resolveRef,
       shouldResolveEagerly: !!this.props.shouldResolveEagerly,
       onPopulate: this.props.onTreePopulate,
-      context: this.props.context,
+      viewMode: this.props.viewMode,
     };
   }
 
@@ -102,7 +102,7 @@ export class JsonSchemaViewerComponent extends React.PureComponent<IJsonSchemaVi
       prevProps.schema !== this.props.schema ||
       prevProps.mergeAllOf !== this.props.mergeAllOf ||
       prevProps.shouldResolveEagerly !== this.props.shouldResolveEagerly ||
-      prevProps.context !== this.props.context
+      prevProps.viewMode !== this.props.viewMode
     ) {
       this.treeStore.defaultExpandedDepth = this.expandedDepth;
       this.tree.treeOptions = this.treeOptions;
@@ -123,9 +123,9 @@ export class JsonSchemaViewerComponent extends React.PureComponent<IJsonSchemaVi
 
     return (
       <div className={cn(className, 'JsonSchemaViewer flex flex-col relative')}>
-        <Context.Provider value={this.props.context ?? 'standalone'}>
+        <ViewModeContext.Provider value={this.props.viewMode ?? 'standalone'}>
           <SchemaTreeComponent expanded={expanded} name={name} schema={schema} treeStore={this.treeStore} {...props} />
-        </Context.Provider>
+        </ViewModeContext.Provider>
       </div>
     );
   }

--- a/src/components/JsonSchemaViewer.tsx
+++ b/src/components/JsonSchemaViewer.tsx
@@ -6,7 +6,7 @@ import * as React from 'react';
 
 import { JSONSchema4 } from 'json-schema';
 import { SchemaTree, SchemaTreeOptions, SchemaTreePopulateHandler, SchemaTreeRefDereferenceFn } from '../tree/tree';
-import { GoToRefHandler, RowRenderer } from '../types';
+import { GoToRefHandler, RowRenderer, ViewContext } from '../types';
 import { isSchemaViewerEmpty } from '../utils/isSchemaViewerEmpty';
 import { SchemaTree as SchemaTreeComponent } from './SchemaTree';
 
@@ -27,7 +27,11 @@ export interface IJsonSchemaViewer {
   onTreePopulate?: SchemaTreePopulateHandler;
   resolveRef?: SchemaTreeRefDereferenceFn;
   shouldResolveEagerly?: boolean;
+  context?: ViewContext;
 }
+
+export const Context = React.createContext<ViewContext>('standalone');
+Context.displayName = 'ViewContext';
 
 export class JsonSchemaViewerComponent extends React.PureComponent<IJsonSchemaViewer & ErrorBoundaryForwardedProps> {
   protected readonly treeStore: TreeStore;
@@ -51,6 +55,7 @@ export class JsonSchemaViewerComponent extends React.PureComponent<IJsonSchemaVi
       resolveRef: this.props.resolveRef,
       shouldResolveEagerly: !!this.props.shouldResolveEagerly,
       onPopulate: this.props.onTreePopulate,
+      context: this.props.context,
     };
   }
 
@@ -103,6 +108,11 @@ export class JsonSchemaViewerComponent extends React.PureComponent<IJsonSchemaVi
       this.tree.schema = this.props.schema;
       this.renderSchema();
     }
+
+    if (prevProps.context !== this.props.context) {
+      this.tree.treeOptions.context = this.props.context ?? 'standalone';
+      this.renderSchema();
+    }
   }
 
   public render() {
@@ -117,7 +127,9 @@ export class JsonSchemaViewerComponent extends React.PureComponent<IJsonSchemaVi
 
     return (
       <div className={cn(className, 'JsonSchemaViewer flex flex-col relative')}>
-        <SchemaTreeComponent expanded={expanded} name={name} schema={schema} treeStore={this.treeStore} {...props} />
+        <Context.Provider value={this.props.context ?? 'standalone'}>
+          <SchemaTreeComponent expanded={expanded} name={name} schema={schema} treeStore={this.treeStore} {...props} />
+        </Context.Provider>
       </div>
     );
   }

--- a/src/components/shared/Validations.tsx
+++ b/src/components/shared/Validations.tsx
@@ -7,7 +7,7 @@ import { Context as ViewContext } from '../JsonSchemaViewer';
 
 export interface IValidations {
   required: boolean;
-  validations: (Dictionary<unknown> | {}) & { deprecated?: boolean; readOnly?: boolean; writeOnly?: boolean };
+  validations: (Dictionary<unknown> | {}) & { deprecated?: boolean; readOnly?: unknown; writeOnly?: unknown };
 }
 
 export const Validations: React.FunctionComponent<IValidations> = ({
@@ -24,12 +24,15 @@ export const Validations: React.FunctionComponent<IValidations> = ({
     </div>
   );
 
-  const visibility =
-    viewMode !== 'standalone' || (readOnly && writeOnly) ? null : readOnly ? (
+  // Show readOnly writeOnly validations only in standalone mode and only if just one of them is present
+  const showVisibilityValidations = viewMode === 'standalone' && !!readOnly !== !!writeOnly;
+  const visibility = showVisibilityValidations ? (
+    readOnly ? (
       <span className="ml-2 text-darken-7 dark:text-lighten-6">read-only</span>
-    ) : writeOnly ? (
+    ) : (
       <span className="ml-2 text-darken-7 dark:text-lighten-6">write-only</span>
-    ) : null;
+    )
+  ) : null;
 
   return (
     <>

--- a/src/components/shared/Validations.tsx
+++ b/src/components/shared/Validations.tsx
@@ -3,7 +3,7 @@ import { Dictionary } from '@stoplight/types';
 import { Popover } from '@stoplight/ui-kit';
 import cn from 'classnames';
 import * as React from 'react';
-import { Context as ViewContext } from '../JsonSchemaViewer';
+import { ViewModeContext } from '../JsonSchemaViewer';
 
 export interface IValidations {
   required: boolean;
@@ -14,7 +14,7 @@ export const Validations: React.FunctionComponent<IValidations> = ({
   required,
   validations: { deprecated, readOnly, writeOnly, ...validations },
 }) => {
-  const viewMode = React.useContext(ViewContext);
+  const viewMode = React.useContext(ViewModeContext);
   const validationCount = Object.keys(validations).length;
 
   const requiredElem = (

--- a/src/components/shared/Validations.tsx
+++ b/src/components/shared/Validations.tsx
@@ -3,16 +3,18 @@ import { Dictionary } from '@stoplight/types';
 import { Popover } from '@stoplight/ui-kit';
 import cn from 'classnames';
 import * as React from 'react';
+import { Context as ViewContext } from '../JsonSchemaViewer';
 
 export interface IValidations {
   required: boolean;
-  validations: (Dictionary<unknown> | {}) & { deprecated?: boolean };
+  validations: (Dictionary<unknown> | {}) & { deprecated?: boolean; readOnly?: boolean; writeOnly?: boolean };
 }
 
 export const Validations: React.FunctionComponent<IValidations> = ({
   required,
-  validations: { deprecated, ...validations },
+  validations: { deprecated, readOnly, writeOnly, ...validations },
 }) => {
+  const viewMode = React.useContext(ViewContext);
   const validationCount = Object.keys(validations).length;
 
   const requiredElem = (
@@ -22,9 +24,17 @@ export const Validations: React.FunctionComponent<IValidations> = ({
     </div>
   );
 
+  const visibility =
+    viewMode !== 'standalone' || (readOnly && writeOnly) ? null : readOnly ? (
+      <span className="ml-2 text-darken-7 dark:text-lighten-6">read-only</span>
+    ) : writeOnly ? (
+      <span className="ml-2 text-darken-7 dark:text-lighten-6">write-only</span>
+    ) : null;
+
   return (
     <>
       {deprecated ? <span className="ml-2 text-orange-7 dark:text-orange-6">deprecated</span> : null}
+      {visibility}
       {validationCount ? (
         <Popover
           boundary="window"

--- a/src/tree/__tests__/tree.spec.ts
+++ b/src/tree/__tests__/tree.spec.ts
@@ -1,6 +1,7 @@
 import { TreeListParentNode } from '@stoplight/tree-list';
 import { JSONSchema4 } from 'json-schema';
 import { ResolvingError } from '../../errors';
+import { ViewContext } from '../../types';
 import { getNodeMetadata } from '../metadata';
 import { SchemaTree, SchemaTreeState } from '../tree';
 import { printTree } from './utils/printTree';
@@ -1364,6 +1365,34 @@ describe('SchemaTree', () => {
         tree.populate();
         expect(printTree(tree)).toMatchSnapshot();
       });
+    });
+
+    test.each(['standalone', 'read', 'write'])('given %s context, should populate proper nodes', context => {
+      const schema: JSONSchema4 = {
+        type: ['string', 'object'],
+        properties: {
+          id: {
+            type: 'string',
+            readOnly: true,
+          },
+          description: {
+            type: 'string',
+            writeOnly: true,
+          },
+        },
+      };
+
+      const tree = new SchemaTree(schema, new SchemaTreeState(), {
+        expandedDepth: Infinity,
+        mergeAllOf: true,
+        resolveRef: void 0,
+        shouldResolveEagerly: true,
+        onPopulate: void 0,
+        context: context as ViewContext,
+      });
+
+      tree.populate();
+      expect(tree.count).toEqual(context === 'standalone' ? 3 : 2);
     });
   });
 

--- a/src/tree/__tests__/tree.spec.ts
+++ b/src/tree/__tests__/tree.spec.ts
@@ -1,7 +1,7 @@
 import { TreeListParentNode } from '@stoplight/tree-list';
 import { JSONSchema4 } from 'json-schema';
 import { ResolvingError } from '../../errors';
-import { ViewContext } from '../../types';
+import { ViewMode } from '../../types';
 import { getNodeMetadata } from '../metadata';
 import { SchemaTree, SchemaTreeState } from '../tree';
 import { printTree } from './utils/printTree';
@@ -1367,7 +1367,7 @@ describe('SchemaTree', () => {
       });
     });
 
-    test.each(['standalone', 'read', 'write'])('given %s context, should populate proper nodes', context => {
+    test.each(['standalone', 'read', 'write'])('given %s mode, should populate proper nodes', mode => {
       const schema: JSONSchema4 = {
         type: ['string', 'object'],
         properties: {
@@ -1388,11 +1388,11 @@ describe('SchemaTree', () => {
         resolveRef: void 0,
         shouldResolveEagerly: true,
         onPopulate: void 0,
-        context: context as ViewContext,
+        viewMode: mode as ViewMode,
       });
 
       tree.populate();
-      expect(tree.count).toEqual(context === 'standalone' ? 3 : 2);
+      expect(tree.count).toEqual(mode === 'standalone' ? 3 : 2);
     });
   });
 

--- a/src/tree/tree.ts
+++ b/src/tree/tree.ts
@@ -4,7 +4,7 @@ import { JsonPath, Optional } from '@stoplight/types';
 import { JSONSchema4 } from 'json-schema';
 import { get as _get, isEqual as _isEqual, isObject as _isObject } from 'lodash';
 import { ResolvingError } from '../errors';
-import { ViewContext } from '../types';
+import { ViewMode } from '../types';
 import { hasRefItems, isRefNode } from '../utils/guards';
 import { getSchemaNodeMetadata } from './metadata';
 import { canStepIn } from './utils/canStepIn';
@@ -30,7 +30,7 @@ export type SchemaTreeOptions = {
   resolveRef: Optional<SchemaTreeRefDereferenceFn>;
   shouldResolveEagerly: boolean;
   onPopulate: Optional<SchemaTreePopulateHandler>;
-  context?: ViewContext;
+  viewMode?: ViewMode;
 };
 
 export { TreeState as SchemaTreeState };
@@ -57,8 +57,8 @@ export class SchemaTree extends Tree {
       onNode: (fragment, node, parentTreeNode, level): boolean => {
         if (
           !!fragment.writeOnly !== !!fragment.readOnly &&
-          ((this.treeOptions.context === 'read' && fragment.writeOnly) ||
-            (this.treeOptions.context === 'write' && fragment.readOnly))
+          ((this.treeOptions.viewMode === 'read' && fragment.writeOnly) ||
+            (this.treeOptions.viewMode === 'write' && fragment.readOnly))
         ) {
           return false;
         }

--- a/src/tree/tree.ts
+++ b/src/tree/tree.ts
@@ -4,6 +4,7 @@ import { JsonPath, Optional } from '@stoplight/types';
 import { JSONSchema4 } from 'json-schema';
 import { get as _get, isEqual as _isEqual, isObject as _isObject } from 'lodash';
 import { ResolvingError } from '../errors';
+import { ViewContext } from '../types';
 import { hasRefItems, isRefNode } from '../utils/guards';
 import { getSchemaNodeMetadata } from './metadata';
 import { canStepIn } from './utils/canStepIn';
@@ -29,6 +30,7 @@ export type SchemaTreeOptions = {
   resolveRef: Optional<SchemaTreeRefDereferenceFn>;
   shouldResolveEagerly: boolean;
   onPopulate: Optional<SchemaTreePopulateHandler>;
+  context?: ViewContext;
 };
 
 export { TreeState as SchemaTreeState };
@@ -53,6 +55,12 @@ export class SchemaTree extends Tree {
     populateTree(this.schema, this.root, 0, [], {
       mergeAllOf: this.treeOptions.mergeAllOf,
       onNode: (fragment, node, parentTreeNode, level): boolean => {
+        if (
+          (this.treeOptions.context === 'read' && fragment.writeOnly) ||
+          (this.treeOptions.context === 'write' && fragment.readOnly)
+        ) {
+          return false;
+        }
         if (
           !this.treeOptions.shouldResolveEagerly &&
           ((isRefNode(node) && node.$ref !== null) || (hasRefItems(node) && node.items.$ref !== null))

--- a/src/tree/tree.ts
+++ b/src/tree/tree.ts
@@ -56,8 +56,9 @@ export class SchemaTree extends Tree {
       mergeAllOf: this.treeOptions.mergeAllOf,
       onNode: (fragment, node, parentTreeNode, level): boolean => {
         if (
-          (this.treeOptions.context === 'read' && fragment.writeOnly) ||
-          (this.treeOptions.context === 'write' && fragment.readOnly)
+          !!fragment.writeOnly !== !!fragment.readOnly &&
+          ((this.treeOptions.context === 'read' && fragment.writeOnly) ||
+            (this.treeOptions.context === 'write' && fragment.readOnly))
         ) {
           return false;
         }

--- a/src/types.ts
+++ b/src/types.ts
@@ -65,3 +65,5 @@ export type RowRenderer = (
   rowOptions: IRowRendererOptions,
   treeStore: TreeStore,
 ) => React.ReactNode;
+
+export type ViewContext = 'read' | 'write' | 'standalone';

--- a/src/types.ts
+++ b/src/types.ts
@@ -66,4 +66,4 @@ export type RowRenderer = (
   treeStore: TreeStore,
 ) => React.ReactNode;
 
-export type ViewContext = 'read' | 'write' | 'standalone';
+export type ViewMode = 'read' | 'write' | 'standalone';


### PR DESCRIPTION
Addresses https://github.com/stoplightio/elements/issues/634

Adds render context that defines whether to render `readOnly` and `writeOnly` nodes (for OAS request/response schemas). 
Brings out `readOnly` and `writeOnly` validations (standalone schemas).

![Peek 2020-10-27 22-20](https://user-images.githubusercontent.com/14196079/97363913-91377a00-18a3-11eb-9170-b1401d66de39.gif)
