### PR TITLE
fix: include subtypes for complex types that include array

### DIFF
--- a/src/tree/__tests__/tree.spec.ts
+++ b/src/tree/__tests__/tree.spec.ts
@@ -1285,6 +1285,46 @@ describe('SchemaTree', () => {
       `);
     });
 
+    test('given complex type that includes array and complex array subtype, should not ignore subtype', () => {
+      const schema: JSONSchema4 = {
+        type: 'object',
+        properties: {
+          items: {
+            type: ['null', 'array'],
+            items: {
+              type: ['string', 'number'],
+            },
+            description:
+              "This description can be long and should truncate once it reaches the end of the row. If it's not truncating then theres and issue that needs to be fixed. Help!",
+          },
+        },
+      };
+
+      const tree = new SchemaTree(schema, new SchemaTreeState(), {
+        expandedDepth: Infinity,
+        mergeAllOf: true,
+        resolveRef: void 0,
+        shouldResolveEagerly: true,
+        onPopulate: void 0,
+      });
+
+      tree.populate();
+      expect(printTree(tree)).toMatchInlineSnapshot(`
+        "└─ #
+           ├─ type: object
+           └─ children
+              └─ 0
+                 └─ #/properties/items
+                    ├─ type
+                    │  ├─ 0: null
+                    │  └─ 1: array
+                    └─ subtype
+                       ├─ 0: string
+                       └─ 1: number
+        "
+      `);
+    });
+
     describe.each(['anyOf', 'oneOf'])('given %s combiner placed next to allOf', combiner => {
       let schema: JSONSchema4;
 

--- a/src/utils/guards.ts
+++ b/src/utils/guards.ts
@@ -5,7 +5,10 @@ import { IArrayNode, ICombinerNode, IRefNode, SchemaKind, SchemaNode } from '../
 export const isArrayNodeWithItems = (
   node: SchemaNode,
 ): node is Omit<IArrayNode, 'items'> & { items: JSONSchema4 | JSONSchema4[] } =>
-  'type' in node && 'items' in node && node.type === SchemaKind.Array && _isObjectLike(node.items);
+  'type' in node &&
+  'items' in node &&
+  (node.type === SchemaKind.Array || (Array.isArray(node.type) && node.type.includes(SchemaKind.Array))) &&
+  _isObjectLike(node.items);
 
 export const isRefNode = (node: SchemaNode): node is IRefNode => '$ref' in node;
 


### PR DESCRIPTION
Unrelated minor issue I spotted while working on https://github.com/stoplightio/platform-internal/issues/4527

Before:
![image](https://user-images.githubusercontent.com/9273484/98049989-176a3800-1e31-11eb-8797-9f50a1963a55.png)

After:
![image](https://user-images.githubusercontent.com/9273484/98050003-205b0980-1e31-11eb-97db-ce51b1ca2e54.png)


