### PR TITLE
feat: drop expanded prop

### DIFF
--- a/src/__stories__/JsonSchemaViewer.tsx
+++ b/src/__stories__/JsonSchemaViewer.tsx
@@ -21,7 +21,6 @@ storiesOf('JsonSchemaViewer', module)
     <JsonSchemaViewer
       schema={schema as JSONSchema4}
       defaultExpandedDepth={number('defaultExpandedDepth', 0)}
-      expanded={boolean('expanded', true)}
       onGoToRef={action('onGoToRef')}
       viewMode={select(
         'viewMode',
@@ -38,7 +37,6 @@ storiesOf('JsonSchemaViewer', module)
     <JsonSchemaViewer
       schema={object('schema', {})}
       defaultExpandedDepth={number('defaultExpandedDepth', 0)}
-      expanded={boolean('expanded', false)}
       onGoToRef={action('onGoToRef')}
       maxRows={number('maxRows', 5)}
       mergeAllOf={boolean('mergeAllOf', true)}
@@ -60,7 +58,6 @@ storiesOf('JsonSchemaViewer', module)
     return (
       <JsonSchemaViewer
         schema={object('schema', schema as JSONSchema4)}
-        expanded={boolean('expanded', true)}
         onGoToRef={action('onGoToRef')}
         maxRows={number('maxRows', 5)}
         mergeAllOf={boolean('mergeAllOf', true)}
@@ -74,7 +71,6 @@ storiesOf('JsonSchemaViewer', module)
         <JsonSchemaViewer
           schema={stressSchema as JSONSchema4}
           defaultExpandedDepth={number('defaultExpandedDepth', 2)}
-          expanded={boolean('expanded', false)}
           onGoToRef={action('onGoToRef')}
           maxRows={number('maxRows', 10)}
           mergeAllOf={boolean('mergeAllOf', true)}
@@ -84,7 +80,6 @@ storiesOf('JsonSchemaViewer', module)
         <JsonSchemaViewer
           schema={stressSchema as JSONSchema4}
           defaultExpandedDepth={number('defaultExpandedDepth', 2)}
-          expanded={boolean('expanded', false)}
           onGoToRef={action('onGoToRef')}
           maxRows={number('maxRows', 10)}
           mergeAllOf={boolean('mergeAllOf', true)}
@@ -96,7 +91,6 @@ storiesOf('JsonSchemaViewer', module)
     <JsonSchemaViewer
       schema={allOfSchema as JSONSchema4}
       defaultExpandedDepth={number('defaultExpandedDepth', 2)}
-      expanded={boolean('expanded', false)}
       mergeAllOf={boolean('mergeAllOf', true)}
       onGoToRef={action('onGoToRef')}
     />
@@ -112,7 +106,6 @@ storiesOf('JsonSchemaViewer', module)
         },
         null,
       )}
-      expanded={boolean('expanded', false)}
       defaultExpandedDepth={number('defaultExpandedDepth', 2)}
       onGoToRef={action('onGoToRef')}
       mergeAllOf={boolean('mergeAllOf', true)}
@@ -145,7 +138,6 @@ storiesOf('JsonSchemaViewer', module)
           },
         },
       }}
-      expanded={boolean('expanded', false)}
       defaultExpandedDepth={number('defaultExpandedDepth', 2)}
       onGoToRef={action('onGoToRef')}
       mergeAllOf={boolean('mergeAllOf', true)}
@@ -158,7 +150,6 @@ storiesOf('JsonSchemaViewer', module)
           <JsonSchemaViewer
             schema={schema as JSONSchema4}
             defaultExpandedDepth={number('defaultExpandedDepth', 2)}
-            expanded={boolean('expanded', false)}
             onGoToRef={action('onGoToRef')}
             mergeAllOf={boolean('mergeAllOf', true)}
           />

--- a/src/__tests__/index.spec.tsx
+++ b/src/__tests__/index.spec.tsx
@@ -21,7 +21,7 @@ describe('HTML Output', () => {
   )('should match %s', filename => {
     const schema = JSON.parse(fs.readFileSync(path.resolve(__dirname, '../__fixtures__/', filename), 'utf8'));
 
-    expect(dumpDom(<JsonSchemaViewer schema={schema} expanded={true} mergeAllOf />)).toMatchSnapshot();
+    expect(dumpDom(<JsonSchemaViewer schema={schema} defaultExpandedDepth={Infinity} mergeAllOf />)).toMatchSnapshot();
   });
 
   describe.each(['anyOf', 'oneOf'])('given %s combiner placed next to allOf', combiner => {
@@ -80,11 +80,15 @@ describe('HTML Output', () => {
     });
 
     it('given allOf merging disabled, should preserve both combiners', () => {
-      expect(dumpDom(<JsonSchemaViewer schema={schema} expanded={true} mergeAllOf={false} />)).toMatchSnapshot();
+      expect(
+        dumpDom(<JsonSchemaViewer schema={schema} defaultExpandedDepth={Infinity} mergeAllOf={false} />),
+      ).toMatchSnapshot();
     });
 
     it('given allOf merging enabled, should merge contents of allOf combiners', () => {
-      expect(dumpDom(<JsonSchemaViewer schema={schema} expanded={true} mergeAllOf />)).toMatchSnapshot();
+      expect(
+        dumpDom(<JsonSchemaViewer schema={schema} defaultExpandedDepth={Infinity} mergeAllOf />),
+      ).toMatchSnapshot();
     });
   });
 
@@ -105,7 +109,7 @@ describe('HTML Output', () => {
       type: 'array',
     };
 
-    expect(dumpDom(<JsonSchemaViewer schema={schema} expanded={true} />)).toMatchSnapshot();
+    expect(dumpDom(<JsonSchemaViewer schema={schema} defaultExpandedDepth={Infinity} />)).toMatchSnapshot();
   });
 
   it.each<ViewMode>(['standalone', 'read', 'write'])('given %s mode, should populate proper nodes', mode => {
@@ -123,7 +127,9 @@ describe('HTML Output', () => {
       },
     };
 
-    expect(dumpDom(<JsonSchemaViewer schema={schema} expanded={true} mergeAllOf viewMode={mode} />)).toMatchSnapshot();
+    expect(
+      dumpDom(<JsonSchemaViewer schema={schema} defaultExpandedDepth={Infinity} mergeAllOf viewMode={mode} />),
+    ).toMatchSnapshot();
   });
 
   it('given multiple object and string type, should process properties', () => {
@@ -139,7 +145,7 @@ describe('HTML Output', () => {
       },
     };
 
-    expect(dumpDom(<JsonSchemaViewer schema={schema} expanded={true} mergeAllOf />)).toMatchSnapshot();
+    expect(dumpDom(<JsonSchemaViewer schema={schema} defaultExpandedDepth={Infinity} mergeAllOf />)).toMatchSnapshot();
   });
 
   it('given complex type that includes array and complex array subtype, should not ignore subtype', () => {
@@ -157,7 +163,7 @@ describe('HTML Output', () => {
       },
     };
 
-    expect(dumpDom(<JsonSchemaViewer schema={schema} expanded={true} mergeAllOf />)).toMatchSnapshot();
+    expect(dumpDom(<JsonSchemaViewer schema={schema} defaultExpandedDepth={Infinity} mergeAllOf />)).toMatchSnapshot();
   });
 
   it('given visible $ref node, should try to inject the title immediately', () => {

--- a/src/components/JsonSchemaViewer.tsx
+++ b/src/components/JsonSchemaViewer.tsx
@@ -17,7 +17,6 @@ export interface IJsonSchemaViewer {
   schema: JSONSchema4;
   emptyText?: string;
   defaultExpandedDepth?: number;
-  expanded?: boolean;
   className?: string;
   maxRows?: number;
   onGoToRef?: GoToRefHandler;
@@ -64,15 +63,7 @@ export class JsonSchemaViewerComponent extends React.PureComponent<
   }
 
   protected get expandedDepth(): number {
-    if (this.props.expanded) {
-      return Infinity; // tree-list kind of equivalent of expanded: all
-    }
-
-    if (this.props.defaultExpandedDepth !== void 0) {
-      return this.props.defaultExpandedDepth;
-    }
-
-    return 1;
+    return this.props.defaultExpandedDepth ?? 1;
   }
 
   protected renderSchema() {
@@ -111,7 +102,7 @@ export class JsonSchemaViewerComponent extends React.PureComponent<
 
   public render() {
     const {
-      props: { emptyText = 'No schema defined', schema, expanded, defaultExpandedDepth, className, ...props },
+      props: { emptyText = 'No schema defined', schema, defaultExpandedDepth, className, ...props },
     } = this;
 
     if (this.state.isEmpty) {
@@ -122,7 +113,7 @@ export class JsonSchemaViewerComponent extends React.PureComponent<
       <Flex pos="relative" h="full" className={cn(className, 'JsonSchemaViewer')}>
         <SchemaTreeContext.Provider value={this.tree}>
           <ViewModeContext.Provider value={this.props.viewMode ?? 'standalone'}>
-            <SchemaTreeComponent expanded={expanded} schema={schema} treeStore={this.treeStore} {...props} />
+            <SchemaTreeComponent schema={schema} treeStore={this.treeStore} {...props} />
           </ViewModeContext.Provider>
         </SchemaTreeContext.Provider>
       </Flex>

--- a/src/components/SchemaTree.tsx
+++ b/src/components/SchemaTree.tsx
@@ -10,7 +10,6 @@ import { validationCount } from './shared/Validations';
 export interface ISchemaTree {
   treeStore: TreeStore;
   schema: JSONSchema4;
-  expanded?: boolean;
   maxRows?: number;
   onGoToRef?: GoToRefHandler;
   rowRenderer?: RowRenderer;


### PR DESCRIPTION
This is breaking from a component's perspective, but not from ours - we usually set `expandedDepth` to 1 and do not use `expanded` anywhere.
Furthemore, migrated a few tests I added yesterday to the other branch.