### PR TITLE
perf: improve performance

### DIFF
--- a/src/__stories__/JsonSchemaViewer.tsx
+++ b/src/__stories__/JsonSchemaViewer.tsx
@@ -63,22 +63,11 @@ storiesOf('JsonSchemaViewer', module)
     );
   })
   .add('stress-test schema', () => (
-    <>
-      <div style={{ height: 345, overflowY: 'scroll' }}>
-        <JsonSchemaViewer
-          schema={stressSchema as JSONSchema4}
-          defaultExpandedDepth={number('defaultExpandedDepth', 2)}
-          onGoToRef={action('onGoToRef')}
-        />
-      </div>
-      <div style={{ height: 345, overflowY: 'scroll' }}>
-        <JsonSchemaViewer
-          schema={stressSchema as JSONSchema4}
-          defaultExpandedDepth={number('defaultExpandedDepth', 2)}
-          onGoToRef={action('onGoToRef')}
-        />
-      </div>
-    </>
+    <JsonSchemaViewer
+      schema={stressSchema as JSONSchema4}
+      defaultExpandedDepth={number('defaultExpandedDepth', 2)}
+      onGoToRef={action('onGoToRef')}
+    />
   ))
   .add('allOf-schema', () => (
     <JsonSchemaViewer

--- a/src/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/src/__tests__/__snapshots__/index.spec.tsx.snap
@@ -1,10 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Expanded depth nested object static given initial level set to 0, should render top 2 levels 1`] = `
-"<div class=\\"sl-stack JsonSchemaViewer sl-flex sl-flex-col sl-items-stretch\\">
+"<div class=\\"JsonSchemaViewer\\">
   <div style=\\"margin-left: 20px\\">
     <div>
-      <div class=\\"min-w-0\\">
+      <div>
         <div>
           <div>
             <div style=\\"width: 20px; height: 20px; position: relative\\" role=\\"button\\"></div>
@@ -20,7 +20,7 @@ exports[`Expanded depth nested object static given initial level set to 0, shoul
     <div>
       <div style=\\"margin-left: 20px\\">
         <div>
-          <div class=\\"min-w-0\\">
+          <div>
             <div>
               <div>
                 <div style=\\"width: 20px; height: 20px; left: -23.5px\\" role=\\"button\\"></div>
@@ -38,7 +38,7 @@ exports[`Expanded depth nested object static given initial level set to 0, shoul
       <div></div>
       <div style=\\"margin-left: 20px\\">
         <div>
-          <div class=\\"min-w-0\\">
+          <div>
             <div>
               <div>
                 <div style=\\"width: 20px; height: 20px; left: -23.5px\\" role=\\"button\\"></div>
@@ -60,10 +60,10 @@ exports[`Expanded depth nested object static given initial level set to 0, shoul
 `;
 
 exports[`Expanded depth nested object static given initial level set to 1, should render top 3 levels 1`] = `
-"<div class=\\"sl-stack JsonSchemaViewer sl-flex sl-flex-col sl-items-stretch\\">
+"<div class=\\"JsonSchemaViewer\\">
   <div style=\\"margin-left: 20px\\">
     <div>
-      <div class=\\"min-w-0\\">
+      <div>
         <div>
           <div>
             <div style=\\"width: 20px; height: 20px; position: relative\\" role=\\"button\\"></div>
@@ -79,7 +79,7 @@ exports[`Expanded depth nested object static given initial level set to 1, shoul
     <div>
       <div style=\\"margin-left: 20px\\">
         <div>
-          <div class=\\"min-w-0\\">
+          <div>
             <div>
               <div>
                 <div style=\\"width: 20px; height: 20px; left: -23.5px\\" role=\\"button\\"></div>
@@ -96,7 +96,7 @@ exports[`Expanded depth nested object static given initial level set to 1, shoul
         <div>
           <div style=\\"margin-left: 20px\\">
             <div>
-              <div class=\\"min-w-0\\">
+              <div>
                 <div>
                   <div>
                     <div style=\\"width: 20px; height: 20px; left: -23.5px\\" role=\\"button\\"></div>
@@ -114,7 +114,7 @@ exports[`Expanded depth nested object static given initial level set to 1, shoul
           <div></div>
           <div style=\\"margin-left: 20px\\">
             <div>
-              <div class=\\"min-w-0\\">
+              <div>
                 <div>
                   <div>
                     <div>
@@ -130,7 +130,7 @@ exports[`Expanded depth nested object static given initial level set to 1, shoul
           <div></div>
           <div style=\\"margin-left: 20px\\">
             <div>
-              <div class=\\"min-w-0\\">
+              <div>
                 <div>
                   <div>
                     <div>
@@ -148,7 +148,7 @@ exports[`Expanded depth nested object static given initial level set to 1, shoul
       <div></div>
       <div style=\\"margin-left: 20px\\">
         <div>
-          <div class=\\"min-w-0\\">
+          <div>
             <div>
               <div>
                 <div style=\\"width: 20px; height: 20px; left: -23.5px\\" role=\\"button\\"></div>
@@ -165,7 +165,7 @@ exports[`Expanded depth nested object static given initial level set to 1, shoul
         <div>
           <div style=\\"margin-left: 20px\\">
             <div>
-              <div class=\\"min-w-0\\">
+              <div>
                 <div>
                   <div>
                     <div>
@@ -181,7 +181,7 @@ exports[`Expanded depth nested object static given initial level set to 1, shoul
           <div></div>
           <div style=\\"margin-left: 20px\\">
             <div>
-              <div class=\\"min-w-0\\">
+              <div>
                 <div>
                   <div>
                     <div>
@@ -203,10 +203,10 @@ exports[`Expanded depth nested object static given initial level set to 1, shoul
 `;
 
 exports[`Expanded depth nested object static given initial level set to 2, should render top 4 levels 1`] = `
-"<div class=\\"sl-stack JsonSchemaViewer sl-flex sl-flex-col sl-items-stretch\\">
+"<div class=\\"JsonSchemaViewer\\">
   <div style=\\"margin-left: 20px\\">
     <div>
-      <div class=\\"min-w-0\\">
+      <div>
         <div>
           <div>
             <div style=\\"width: 20px; height: 20px; position: relative\\" role=\\"button\\"></div>
@@ -222,7 +222,7 @@ exports[`Expanded depth nested object static given initial level set to 2, shoul
     <div>
       <div style=\\"margin-left: 20px\\">
         <div>
-          <div class=\\"min-w-0\\">
+          <div>
             <div>
               <div>
                 <div style=\\"width: 20px; height: 20px; left: -23.5px\\" role=\\"button\\"></div>
@@ -239,7 +239,7 @@ exports[`Expanded depth nested object static given initial level set to 2, shoul
         <div>
           <div style=\\"margin-left: 20px\\">
             <div>
-              <div class=\\"min-w-0\\">
+              <div>
                 <div>
                   <div>
                     <div style=\\"width: 20px; height: 20px; left: -23.5px\\" role=\\"button\\"></div>
@@ -256,7 +256,7 @@ exports[`Expanded depth nested object static given initial level set to 2, shoul
             <div>
               <div style=\\"margin-left: 20px\\">
                 <div>
-                  <div class=\\"min-w-0\\">
+                  <div>
                     <div>
                       <div>
                         <div>
@@ -274,7 +274,7 @@ exports[`Expanded depth nested object static given initial level set to 2, shoul
           <div></div>
           <div style=\\"margin-left: 20px\\">
             <div>
-              <div class=\\"min-w-0\\">
+              <div>
                 <div>
                   <div>
                     <div>
@@ -290,7 +290,7 @@ exports[`Expanded depth nested object static given initial level set to 2, shoul
           <div></div>
           <div style=\\"margin-left: 20px\\">
             <div>
-              <div class=\\"min-w-0\\">
+              <div>
                 <div>
                   <div>
                     <div>
@@ -308,7 +308,7 @@ exports[`Expanded depth nested object static given initial level set to 2, shoul
       <div></div>
       <div style=\\"margin-left: 20px\\">
         <div>
-          <div class=\\"min-w-0\\">
+          <div>
             <div>
               <div>
                 <div style=\\"width: 20px; height: 20px; left: -23.5px\\" role=\\"button\\"></div>
@@ -325,7 +325,7 @@ exports[`Expanded depth nested object static given initial level set to 2, shoul
         <div>
           <div style=\\"margin-left: 20px\\">
             <div>
-              <div class=\\"min-w-0\\">
+              <div>
                 <div>
                   <div>
                     <div>
@@ -341,7 +341,7 @@ exports[`Expanded depth nested object static given initial level set to 2, shoul
           <div></div>
           <div style=\\"margin-left: 20px\\">
             <div>
-              <div class=\\"min-w-0\\">
+              <div>
                 <div>
                   <div>
                     <div>
@@ -363,10 +363,10 @@ exports[`Expanded depth nested object static given initial level set to 2, shoul
 `;
 
 exports[`HTML Output given anyOf combiner placed next to allOf given allOf merging enabled, should merge contents of allOf combiners 1`] = `
-"<div class=\\"sl-stack JsonSchemaViewer sl-flex sl-flex-col sl-items-stretch\\">
+"<div class=\\"JsonSchemaViewer\\">
   <div style=\\"margin-left: 20px\\">
     <div>
-      <div class=\\"min-w-0\\">
+      <div>
         <div>
           <div>
             <div style=\\"width: 20px; height: 20px; position: relative\\" role=\\"button\\"></div>
@@ -382,7 +382,7 @@ exports[`HTML Output given anyOf combiner placed next to allOf given allOf mergi
     <div>
       <div style=\\"margin-left: 20px\\">
         <div>
-          <div class=\\"min-w-0\\">
+          <div>
             <div>
               <div>
                 <div style=\\"width: 20px; height: 20px; left: -23.5px\\" role=\\"button\\"></div>
@@ -398,7 +398,7 @@ exports[`HTML Output given anyOf combiner placed next to allOf given allOf mergi
         <div>
           <div style=\\"margin-left: 20px\\">
             <div>
-              <div class=\\"min-w-0\\">
+              <div>
                 <div>
                   <div>
                     <div>
@@ -420,7 +420,7 @@ exports[`HTML Output given anyOf combiner placed next to allOf given allOf mergi
           <div></div>
           <div style=\\"margin-left: 20px\\">
             <div>
-              <div class=\\"min-w-0\\">
+              <div>
                 <div>
                   <div>
                     <div>
@@ -437,7 +437,7 @@ exports[`HTML Output given anyOf combiner placed next to allOf given allOf mergi
           <div></div>
           <div style=\\"margin-left: 20px\\">
             <div>
-              <div class=\\"min-w-0\\">
+              <div>
                 <div>
                   <div>
                     <div>
@@ -453,7 +453,7 @@ exports[`HTML Output given anyOf combiner placed next to allOf given allOf mergi
           <div></div>
           <div style=\\"margin-left: 20px\\">
             <div>
-              <div class=\\"min-w-0\\">
+              <div>
                 <div>
                   <div>
                     <div>
@@ -469,7 +469,7 @@ exports[`HTML Output given anyOf combiner placed next to allOf given allOf mergi
           <div></div>
           <div style=\\"margin-left: 20px\\">
             <div>
-              <div class=\\"min-w-0\\">
+              <div>
                 <div>
                   <div>
                     <div>
@@ -487,7 +487,7 @@ exports[`HTML Output given anyOf combiner placed next to allOf given allOf mergi
       <div></div>
       <div style=\\"margin-left: 20px\\">
         <div>
-          <div class=\\"min-w-0\\">
+          <div>
             <div>
               <div>
                 <div style=\\"width: 20px; height: 20px; left: -23.5px\\" role=\\"button\\"></div>
@@ -504,7 +504,7 @@ exports[`HTML Output given anyOf combiner placed next to allOf given allOf mergi
         <div>
           <div style=\\"margin-left: 20px\\">
             <div>
-              <div class=\\"min-w-0\\">
+              <div>
                 <div>
                   <div>
                     <div>
@@ -526,7 +526,7 @@ exports[`HTML Output given anyOf combiner placed next to allOf given allOf mergi
           <div></div>
           <div style=\\"margin-left: 20px\\">
             <div>
-              <div class=\\"min-w-0\\">
+              <div>
                 <div>
                   <div>
                     <div>
@@ -543,7 +543,7 @@ exports[`HTML Output given anyOf combiner placed next to allOf given allOf mergi
           <div></div>
           <div style=\\"margin-left: 20px\\">
             <div>
-              <div class=\\"min-w-0\\">
+              <div>
                 <div>
                   <div>
                     <div>
@@ -559,7 +559,7 @@ exports[`HTML Output given anyOf combiner placed next to allOf given allOf mergi
           <div></div>
           <div style=\\"margin-left: 20px\\">
             <div>
-              <div class=\\"min-w-0\\">
+              <div>
                 <div>
                   <div>
                     <div>
@@ -581,10 +581,10 @@ exports[`HTML Output given anyOf combiner placed next to allOf given allOf mergi
 `;
 
 exports[`HTML Output given array with oneOf containing items, should merge it correctly 1`] = `
-"<div class=\\"sl-stack JsonSchemaViewer sl-flex sl-flex-col sl-items-stretch\\">
+"<div class=\\"JsonSchemaViewer\\">
   <div style=\\"margin-left: 20px\\">
     <div>
-      <div class=\\"min-w-0\\">
+      <div>
         <div>
           <div>
             <div style=\\"width: 20px; height: 20px; position: relative\\" role=\\"button\\"></div>
@@ -600,7 +600,7 @@ exports[`HTML Output given array with oneOf containing items, should merge it co
     <div>
       <div style=\\"margin-left: 20px\\">
         <div>
-          <div class=\\"min-w-0\\">
+          <div>
             <div>
               <div>
                 <div><span>array[string]</span></div>
@@ -613,7 +613,7 @@ exports[`HTML Output given array with oneOf containing items, should merge it co
       <div></div>
       <div style=\\"margin-left: 20px\\">
         <div>
-          <div class=\\"min-w-0\\">
+          <div>
             <div>
               <div>
                 <div style=\\"top: -9px; height: 1px\\"><div>or</div></div>
@@ -631,10 +631,10 @@ exports[`HTML Output given array with oneOf containing items, should merge it co
 `;
 
 exports[`HTML Output given complex type that includes array and complex array subtype, should not ignore subtype 1`] = `
-"<div class=\\"sl-stack JsonSchemaViewer sl-flex sl-flex-col sl-items-stretch\\">
+"<div class=\\"JsonSchemaViewer\\">
   <div style=\\"margin-left: 20px\\">
     <div>
-      <div class=\\"min-w-0\\">
+      <div>
         <div>
           <div>
             <div style=\\"width: 20px; height: 20px; position: relative\\" role=\\"button\\"></div>
@@ -650,7 +650,7 @@ exports[`HTML Output given complex type that includes array and complex array su
     <div>
       <div style=\\"margin-left: 20px\\">
         <div>
-          <div class=\\"min-w-0\\">
+          <div>
             <div>
               <div>
                 <div>
@@ -682,10 +682,10 @@ exports[`HTML Output given complex type that includes array and complex array su
 `;
 
 exports[`HTML Output given multiple object and string type, should process properties 1`] = `
-"<div class=\\"sl-stack JsonSchemaViewer sl-flex sl-flex-col sl-items-stretch\\">
+"<div class=\\"JsonSchemaViewer\\">
   <div style=\\"margin-left: 20px\\">
     <div>
-      <div class=\\"min-w-0\\">
+      <div>
         <div>
           <div>
             <div style=\\"width: 20px; height: 20px; position: relative\\" role=\\"button\\"></div>
@@ -705,7 +705,7 @@ exports[`HTML Output given multiple object and string type, should process prope
     <div>
       <div style=\\"margin-left: 20px\\">
         <div>
-          <div class=\\"min-w-0\\">
+          <div>
             <div>
               <div>
                 <div>
@@ -725,10 +725,10 @@ exports[`HTML Output given multiple object and string type, should process prope
 `;
 
 exports[`HTML Output given oneOf combiner placed next to allOf given allOf merging enabled, should merge contents of allOf combiners 1`] = `
-"<div class=\\"sl-stack JsonSchemaViewer sl-flex sl-flex-col sl-items-stretch\\">
+"<div class=\\"JsonSchemaViewer\\">
   <div style=\\"margin-left: 20px\\">
     <div>
-      <div class=\\"min-w-0\\">
+      <div>
         <div>
           <div>
             <div style=\\"width: 20px; height: 20px; position: relative\\" role=\\"button\\"></div>
@@ -744,7 +744,7 @@ exports[`HTML Output given oneOf combiner placed next to allOf given allOf mergi
     <div>
       <div style=\\"margin-left: 20px\\">
         <div>
-          <div class=\\"min-w-0\\">
+          <div>
             <div>
               <div>
                 <div style=\\"width: 20px; height: 20px; left: -23.5px\\" role=\\"button\\"></div>
@@ -760,7 +760,7 @@ exports[`HTML Output given oneOf combiner placed next to allOf given allOf mergi
         <div>
           <div style=\\"margin-left: 20px\\">
             <div>
-              <div class=\\"min-w-0\\">
+              <div>
                 <div>
                   <div>
                     <div>
@@ -782,7 +782,7 @@ exports[`HTML Output given oneOf combiner placed next to allOf given allOf mergi
           <div></div>
           <div style=\\"margin-left: 20px\\">
             <div>
-              <div class=\\"min-w-0\\">
+              <div>
                 <div>
                   <div>
                     <div>
@@ -799,7 +799,7 @@ exports[`HTML Output given oneOf combiner placed next to allOf given allOf mergi
           <div></div>
           <div style=\\"margin-left: 20px\\">
             <div>
-              <div class=\\"min-w-0\\">
+              <div>
                 <div>
                   <div>
                     <div>
@@ -815,7 +815,7 @@ exports[`HTML Output given oneOf combiner placed next to allOf given allOf mergi
           <div></div>
           <div style=\\"margin-left: 20px\\">
             <div>
-              <div class=\\"min-w-0\\">
+              <div>
                 <div>
                   <div>
                     <div>
@@ -831,7 +831,7 @@ exports[`HTML Output given oneOf combiner placed next to allOf given allOf mergi
           <div></div>
           <div style=\\"margin-left: 20px\\">
             <div>
-              <div class=\\"min-w-0\\">
+              <div>
                 <div>
                   <div>
                     <div>
@@ -849,7 +849,7 @@ exports[`HTML Output given oneOf combiner placed next to allOf given allOf mergi
       <div></div>
       <div style=\\"margin-left: 20px\\">
         <div>
-          <div class=\\"min-w-0\\">
+          <div>
             <div>
               <div>
                 <div style=\\"width: 20px; height: 20px; left: -23.5px\\" role=\\"button\\"></div>
@@ -866,7 +866,7 @@ exports[`HTML Output given oneOf combiner placed next to allOf given allOf mergi
         <div>
           <div style=\\"margin-left: 20px\\">
             <div>
-              <div class=\\"min-w-0\\">
+              <div>
                 <div>
                   <div>
                     <div>
@@ -888,7 +888,7 @@ exports[`HTML Output given oneOf combiner placed next to allOf given allOf mergi
           <div></div>
           <div style=\\"margin-left: 20px\\">
             <div>
-              <div class=\\"min-w-0\\">
+              <div>
                 <div>
                   <div>
                     <div>
@@ -905,7 +905,7 @@ exports[`HTML Output given oneOf combiner placed next to allOf given allOf mergi
           <div></div>
           <div style=\\"margin-left: 20px\\">
             <div>
-              <div class=\\"min-w-0\\">
+              <div>
                 <div>
                   <div>
                     <div>
@@ -921,7 +921,7 @@ exports[`HTML Output given oneOf combiner placed next to allOf given allOf mergi
           <div></div>
           <div style=\\"margin-left: 20px\\">
             <div>
-              <div class=\\"min-w-0\\">
+              <div>
                 <div>
                   <div>
                     <div>
@@ -943,10 +943,10 @@ exports[`HTML Output given oneOf combiner placed next to allOf given allOf mergi
 `;
 
 exports[`HTML Output given read mode, should populate proper nodes 1`] = `
-"<div class=\\"sl-stack JsonSchemaViewer sl-flex sl-flex-col sl-items-stretch\\">
+"<div class=\\"JsonSchemaViewer\\">
   <div style=\\"margin-left: 20px\\">
     <div>
-      <div class=\\"min-w-0\\">
+      <div>
         <div>
           <div>
             <div style=\\"width: 20px; height: 20px; position: relative\\" role=\\"button\\"></div>
@@ -966,7 +966,7 @@ exports[`HTML Output given read mode, should populate proper nodes 1`] = `
     <div>
       <div style=\\"margin-left: 20px\\">
         <div>
-          <div class=\\"min-w-0\\">
+          <div>
             <div>
               <div>
                 <div>
@@ -986,10 +986,10 @@ exports[`HTML Output given read mode, should populate proper nodes 1`] = `
 `;
 
 exports[`HTML Output given standalone mode, should populate proper nodes 1`] = `
-"<div class=\\"sl-stack JsonSchemaViewer sl-flex sl-flex-col sl-items-stretch\\">
+"<div class=\\"JsonSchemaViewer\\">
   <div style=\\"margin-left: 20px\\">
     <div>
-      <div class=\\"min-w-0\\">
+      <div>
         <div>
           <div>
             <div style=\\"width: 20px; height: 20px; position: relative\\" role=\\"button\\"></div>
@@ -1009,7 +1009,7 @@ exports[`HTML Output given standalone mode, should populate proper nodes 1`] = `
     <div>
       <div style=\\"margin-left: 20px\\">
         <div>
-          <div class=\\"min-w-0\\">
+          <div>
             <div>
               <div>
                 <div>
@@ -1026,7 +1026,7 @@ exports[`HTML Output given standalone mode, should populate proper nodes 1`] = `
       <div></div>
       <div style=\\"margin-left: 20px\\">
         <div>
-          <div class=\\"min-w-0\\">
+          <div>
             <div>
               <div>
                 <div>
@@ -1047,10 +1047,10 @@ exports[`HTML Output given standalone mode, should populate proper nodes 1`] = `
 `;
 
 exports[`HTML Output given visible $ref node, should try to inject the title immediately 1`] = `
-"<div class=\\"sl-stack JsonSchemaViewer sl-flex sl-flex-col sl-items-stretch\\">
+"<div class=\\"JsonSchemaViewer\\">
   <div style=\\"margin-left: 20px\\">
     <div>
-      <div class=\\"min-w-0\\">
+      <div>
         <div>
           <div>
             <div style=\\"width: 20px; height: 20px; position: relative\\" role=\\"button\\"></div>
@@ -1066,7 +1066,7 @@ exports[`HTML Output given visible $ref node, should try to inject the title imm
     <div>
       <div style=\\"margin-left: 20px\\">
         <div>
-          <div class=\\"min-w-0\\">
+          <div>
             <div>
               <div>
                 <div style=\\"width: 20px; height: 20px; left: -23.5px\\" role=\\"button\\"></div>
@@ -1083,7 +1083,7 @@ exports[`HTML Output given visible $ref node, should try to inject the title imm
         <div>
           <div style=\\"margin-left: 20px\\">
             <div>
-              <div class=\\"min-w-0\\">
+              <div>
                 <div>
                   <div>
                     <div>
@@ -1101,7 +1101,7 @@ exports[`HTML Output given visible $ref node, should try to inject the title imm
       <div></div>
       <div style=\\"margin-left: 20px\\">
         <div>
-          <div class=\\"min-w-0\\">
+          <div>
             <div>
               <div>
                 <div style=\\"width: 20px; height: 20px; left: -23.5px\\" role=\\"button\\"></div>
@@ -1123,10 +1123,10 @@ exports[`HTML Output given visible $ref node, should try to inject the title imm
 `;
 
 exports[`HTML Output given write mode, should populate proper nodes 1`] = `
-"<div class=\\"sl-stack JsonSchemaViewer sl-flex sl-flex-col sl-items-stretch\\">
+"<div class=\\"JsonSchemaViewer\\">
   <div style=\\"margin-left: 20px\\">
     <div>
-      <div class=\\"min-w-0\\">
+      <div>
         <div>
           <div>
             <div style=\\"width: 20px; height: 20px; position: relative\\" role=\\"button\\"></div>
@@ -1146,7 +1146,7 @@ exports[`HTML Output given write mode, should populate proper nodes 1`] = `
     <div>
       <div style=\\"margin-left: 20px\\">
         <div>
-          <div class=\\"min-w-0\\">
+          <div>
             <div>
               <div>
                 <div>
@@ -1166,10 +1166,10 @@ exports[`HTML Output given write mode, should populate proper nodes 1`] = `
 `;
 
 exports[`HTML Output should match arrays/of-allofs.json 1`] = `
-"<div class=\\"sl-stack JsonSchemaViewer sl-flex sl-flex-col sl-items-stretch\\">
+"<div class=\\"JsonSchemaViewer\\">
   <div style=\\"margin-left: 20px\\">
     <div>
-      <div class=\\"min-w-0\\">
+      <div>
         <div>
           <div>
             <div style=\\"width: 20px; height: 20px; position: relative\\" role=\\"button\\"></div>
@@ -1185,7 +1185,7 @@ exports[`HTML Output should match arrays/of-allofs.json 1`] = `
     <div>
       <div style=\\"margin-left: 20px\\">
         <div>
-          <div class=\\"min-w-0\\">
+          <div>
             <div>
               <div>
                 <div style=\\"width: 20px; height: 20px; left: -23.5px\\" role=\\"button\\"></div>
@@ -1202,7 +1202,7 @@ exports[`HTML Output should match arrays/of-allofs.json 1`] = `
         <div>
           <div style=\\"margin-left: 20px\\">
             <div>
-              <div class=\\"min-w-0\\">
+              <div>
                 <div>
                   <div>
                     <div>
@@ -1218,7 +1218,7 @@ exports[`HTML Output should match arrays/of-allofs.json 1`] = `
           <div></div>
           <div style=\\"margin-left: 20px\\">
             <div>
-              <div class=\\"min-w-0\\">
+              <div>
                 <div>
                   <div>
                     <div>
@@ -1240,10 +1240,10 @@ exports[`HTML Output should match arrays/of-allofs.json 1`] = `
 `;
 
 exports[`HTML Output should match arrays/of-arrays.json 1`] = `
-"<div class=\\"sl-stack JsonSchemaViewer sl-flex sl-flex-col sl-items-stretch\\">
+"<div class=\\"JsonSchemaViewer\\">
   <div style=\\"margin-left: 20px\\">
     <div>
-      <div class=\\"min-w-0\\">
+      <div>
         <div>
           <div>
             <div style=\\"width: 20px; height: 20px; position: relative\\" role=\\"button\\"></div>
@@ -1259,7 +1259,7 @@ exports[`HTML Output should match arrays/of-arrays.json 1`] = `
     <div>
       <div style=\\"margin-left: 20px\\">
         <div>
-          <div class=\\"min-w-0\\">
+          <div>
             <div>
               <div>
                 <div>
@@ -1275,7 +1275,7 @@ exports[`HTML Output should match arrays/of-arrays.json 1`] = `
       <div></div>
       <div style=\\"margin-left: 20px\\">
         <div>
-          <div class=\\"min-w-0\\">
+          <div>
             <div>
               <div>
                 <div>
@@ -1295,10 +1295,10 @@ exports[`HTML Output should match arrays/of-arrays.json 1`] = `
 `;
 
 exports[`HTML Output should match arrays/of-objects.json 1`] = `
-"<div class=\\"sl-stack JsonSchemaViewer sl-flex sl-flex-col sl-items-stretch\\">
+"<div class=\\"JsonSchemaViewer\\">
   <div style=\\"margin-left: 20px\\">
     <div>
-      <div class=\\"min-w-0\\">
+      <div>
         <div>
           <div>
             <div style=\\"width: 20px; height: 20px; position: relative\\" role=\\"button\\"></div>
@@ -1314,7 +1314,7 @@ exports[`HTML Output should match arrays/of-objects.json 1`] = `
     <div>
       <div style=\\"margin-left: 20px\\">
         <div>
-          <div class=\\"min-w-0\\">
+          <div>
             <div>
               <div>
                 <div style=\\"width: 20px; height: 20px; left: -23.5px\\" role=\\"button\\"></div>
@@ -1331,7 +1331,7 @@ exports[`HTML Output should match arrays/of-objects.json 1`] = `
         <div>
           <div style=\\"margin-left: 20px\\">
             <div>
-              <div class=\\"min-w-0\\">
+              <div>
                 <div>
                   <div>
                     <div>
@@ -1353,7 +1353,7 @@ exports[`HTML Output should match arrays/of-objects.json 1`] = `
 `;
 
 exports[`HTML Output should match arrays/of-refs.json 1`] = `
-"<div class=\\"sl-stack JsonSchemaViewer sl-flex sl-flex-col sl-items-stretch\\">
+"<div class=\\"JsonSchemaViewer\\">
   <div style=\\"margin-left: 20px\\">
     <div>
       <div>
@@ -1389,10 +1389,10 @@ exports[`HTML Output should match arrays/of-refs.json 1`] = `
 `;
 
 exports[`HTML Output should match arrays/with-multiple-arrayish-items.json 1`] = `
-"<div class=\\"sl-stack JsonSchemaViewer sl-flex sl-flex-col sl-items-stretch\\">
+"<div class=\\"JsonSchemaViewer\\">
   <div style=\\"margin-left: 20px\\">
     <div>
-      <div class=\\"min-w-0\\">
+      <div>
         <div>
           <div>
             <div style=\\"width: 20px; height: 20px; position: relative\\" role=\\"button\\"></div>
@@ -1408,7 +1408,7 @@ exports[`HTML Output should match arrays/with-multiple-arrayish-items.json 1`] =
     <div>
       <div style=\\"margin-left: 20px\\">
         <div>
-          <div class=\\"min-w-0\\">
+          <div>
             <div>
               <div>
                 <div><span>number</span></div>
@@ -1421,7 +1421,7 @@ exports[`HTML Output should match arrays/with-multiple-arrayish-items.json 1`] =
       <div></div>
       <div style=\\"margin-left: 20px\\">
         <div>
-          <div class=\\"min-w-0\\">
+          <div>
             <div>
               <div>
                 <div style=\\"width: 20px; height: 20px; left: -23.5px\\" role=\\"button\\"></div>
@@ -1437,7 +1437,7 @@ exports[`HTML Output should match arrays/with-multiple-arrayish-items.json 1`] =
         <div>
           <div style=\\"margin-left: 20px\\">
             <div>
-              <div class=\\"min-w-0\\">
+              <div>
                 <div>
                   <div>
                     <div>
@@ -1454,7 +1454,7 @@ exports[`HTML Output should match arrays/with-multiple-arrayish-items.json 1`] =
           <div></div>
           <div style=\\"margin-left: 20px\\">
             <div>
-              <div class=\\"min-w-0\\">
+              <div>
                 <div>
                   <div>
                     <div>
@@ -1471,7 +1471,7 @@ exports[`HTML Output should match arrays/with-multiple-arrayish-items.json 1`] =
           <div></div>
           <div style=\\"margin-left: 20px\\">
             <div>
-              <div class=\\"min-w-0\\">
+              <div>
                 <div>
                   <div>
                     <div>
@@ -1493,10 +1493,10 @@ exports[`HTML Output should match arrays/with-multiple-arrayish-items.json 1`] =
 `;
 
 exports[`HTML Output should match arrays/with-ordered-items.json 1`] = `
-"<div class=\\"sl-stack JsonSchemaViewer sl-flex sl-flex-col sl-items-stretch\\">
+"<div class=\\"JsonSchemaViewer\\">
   <div style=\\"margin-left: 20px\\">
     <div>
-      <div class=\\"min-w-0\\">
+      <div>
         <div>
           <div>
             <div style=\\"width: 20px; height: 20px; position: relative\\" role=\\"button\\"></div>
@@ -1512,7 +1512,7 @@ exports[`HTML Output should match arrays/with-ordered-items.json 1`] = `
     <div>
       <div style=\\"margin-left: 20px\\">
         <div>
-          <div class=\\"min-w-0\\">
+          <div>
             <div>
               <div>
                 <div><span>number</span></div>
@@ -1525,7 +1525,7 @@ exports[`HTML Output should match arrays/with-ordered-items.json 1`] = `
       <div></div>
       <div style=\\"margin-left: 20px\\">
         <div>
-          <div class=\\"min-w-0\\">
+          <div>
             <div>
               <div>
                 <div><span>string</span></div>
@@ -1542,10 +1542,10 @@ exports[`HTML Output should match arrays/with-ordered-items.json 1`] = `
 `;
 
 exports[`HTML Output should match arrays/with-single-arrayish-items.json 1`] = `
-"<div class=\\"sl-stack JsonSchemaViewer sl-flex sl-flex-col sl-items-stretch\\">
+"<div class=\\"JsonSchemaViewer\\">
   <div style=\\"margin-left: 20px\\">
     <div>
-      <div class=\\"min-w-0\\">
+      <div>
         <div>
           <div>
             <div style=\\"width: 20px; height: 20px; position: relative\\" role=\\"button\\"></div>
@@ -1561,7 +1561,7 @@ exports[`HTML Output should match arrays/with-single-arrayish-items.json 1`] = `
     <div>
       <div style=\\"margin-left: 20px\\">
         <div>
-          <div class=\\"min-w-0\\">
+          <div>
             <div>
               <div>
                 <div>
@@ -1578,7 +1578,7 @@ exports[`HTML Output should match arrays/with-single-arrayish-items.json 1`] = `
       <div></div>
       <div style=\\"margin-left: 20px\\">
         <div>
-          <div class=\\"min-w-0\\">
+          <div>
             <div>
               <div>
                 <div>
@@ -1595,7 +1595,7 @@ exports[`HTML Output should match arrays/with-single-arrayish-items.json 1`] = `
       <div></div>
       <div style=\\"margin-left: 20px\\">
         <div>
-          <div class=\\"min-w-0\\">
+          <div>
             <div>
               <div>
                 <div>
@@ -1615,10 +1615,10 @@ exports[`HTML Output should match arrays/with-single-arrayish-items.json 1`] = `
 `;
 
 exports[`HTML Output should match combiners/allOfs/base.json 1`] = `
-"<div class=\\"sl-stack JsonSchemaViewer sl-flex sl-flex-col sl-items-stretch\\">
+"<div class=\\"JsonSchemaViewer\\">
   <div style=\\"margin-left: 20px\\">
     <div>
-      <div class=\\"min-w-0\\">
+      <div>
         <div>
           <div>
             <div style=\\"width: 20px; height: 20px; position: relative\\" role=\\"button\\"></div>
@@ -1634,7 +1634,7 @@ exports[`HTML Output should match combiners/allOfs/base.json 1`] = `
     <div>
       <div style=\\"margin-left: 20px\\">
         <div>
-          <div class=\\"min-w-0\\">
+          <div>
             <div>
               <div>
                 <div style=\\"width: 20px; height: 20px; left: -23.5px\\" role=\\"button\\"></div>
@@ -1651,7 +1651,7 @@ exports[`HTML Output should match combiners/allOfs/base.json 1`] = `
         <div>
           <div style=\\"margin-left: 20px\\">
             <div>
-              <div class=\\"min-w-0\\">
+              <div>
                 <div>
                   <div>
                     <div>
@@ -1668,7 +1668,7 @@ exports[`HTML Output should match combiners/allOfs/base.json 1`] = `
           <div></div>
           <div style=\\"margin-left: 20px\\">
             <div>
-              <div class=\\"min-w-0\\">
+              <div>
                 <div>
                   <div>
                     <div>
@@ -1687,7 +1687,7 @@ exports[`HTML Output should match combiners/allOfs/base.json 1`] = `
       <div></div>
       <div style=\\"margin-left: 20px\\">
         <div>
-          <div class=\\"min-w-0\\">
+          <div>
             <div>
               <div>
                 <div>
@@ -1707,7 +1707,7 @@ exports[`HTML Output should match combiners/allOfs/base.json 1`] = `
       <div></div>
       <div style=\\"margin-left: 20px\\">
         <div>
-          <div class=\\"min-w-0\\">
+          <div>
             <div>
               <div>
                 <div>
@@ -1724,7 +1724,7 @@ exports[`HTML Output should match combiners/allOfs/base.json 1`] = `
       <div></div>
       <div style=\\"margin-left: 20px\\">
         <div>
-          <div class=\\"min-w-0\\">
+          <div>
             <div>
               <div>
                 <div style=\\"width: 20px; height: 20px; left: -23.5px\\" role=\\"button\\"></div>
@@ -1741,7 +1741,7 @@ exports[`HTML Output should match combiners/allOfs/base.json 1`] = `
         <div>
           <div style=\\"margin-left: 20px\\">
             <div>
-              <div class=\\"min-w-0\\">
+              <div>
                 <div>
                   <div>
                     <div>
@@ -1763,7 +1763,7 @@ exports[`HTML Output should match combiners/allOfs/base.json 1`] = `
       <div></div>
       <div style=\\"margin-left: 20px\\">
         <div>
-          <div class=\\"min-w-0\\">
+          <div>
             <div>
               <div>
                 <div style=\\"width: 20px; height: 20px; left: -23.5px\\" role=\\"button\\"></div>
@@ -1780,7 +1780,7 @@ exports[`HTML Output should match combiners/allOfs/base.json 1`] = `
         <div>
           <div style=\\"margin-left: 20px\\">
             <div>
-              <div class=\\"min-w-0\\">
+              <div>
                 <div>
                   <div>
                     <div>
@@ -1797,7 +1797,7 @@ exports[`HTML Output should match combiners/allOfs/base.json 1`] = `
           <div></div>
           <div style=\\"margin-left: 20px\\">
             <div>
-              <div class=\\"min-w-0\\">
+              <div>
                 <div>
                   <div>
                     <div>
@@ -1814,7 +1814,7 @@ exports[`HTML Output should match combiners/allOfs/base.json 1`] = `
           <div></div>
           <div style=\\"margin-left: 20px\\">
             <div>
-              <div class=\\"min-w-0\\">
+              <div>
                 <div>
                   <div>
                     <div>
@@ -1831,7 +1831,7 @@ exports[`HTML Output should match combiners/allOfs/base.json 1`] = `
           <div></div>
           <div style=\\"margin-left: 20px\\">
             <div>
-              <div class=\\"min-w-0\\">
+              <div>
                 <div>
                   <div>
                     <div>
@@ -1853,10 +1853,10 @@ exports[`HTML Output should match combiners/allOfs/base.json 1`] = `
 `;
 
 exports[`HTML Output should match combiners/allOfs/complex.json 1`] = `
-"<div class=\\"sl-stack JsonSchemaViewer sl-flex sl-flex-col sl-items-stretch\\">
+"<div class=\\"JsonSchemaViewer\\">
   <div style=\\"margin-left: 20px\\">
     <div>
-      <div class=\\"min-w-0\\">
+      <div>
         <div>
           <div>
             <div style=\\"width: 20px; height: 20px; position: relative\\" role=\\"button\\"></div>
@@ -1872,7 +1872,7 @@ exports[`HTML Output should match combiners/allOfs/complex.json 1`] = `
     <div>
       <div style=\\"margin-left: 20px\\">
         <div>
-          <div class=\\"min-w-0\\">
+          <div>
             <div>
               <div>
                 <div style=\\"width: 20px; height: 20px; left: -23.5px\\" role=\\"button\\"></div>
@@ -1889,7 +1889,7 @@ exports[`HTML Output should match combiners/allOfs/complex.json 1`] = `
         <div>
           <div style=\\"margin-left: 20px\\">
             <div>
-              <div class=\\"min-w-0\\">
+              <div>
                 <div>
                   <div>
                     <div style=\\"width: 20px; height: 20px; left: -23.5px\\" role=\\"button\\"></div>
@@ -1906,7 +1906,7 @@ exports[`HTML Output should match combiners/allOfs/complex.json 1`] = `
             <div>
               <div style=\\"margin-left: 20px\\">
                 <div>
-                  <div class=\\"min-w-0\\">
+                  <div>
                     <div>
                       <div>
                         <div style=\\"width: 20px; height: 20px; left: -23.5px\\" role=\\"button\\"></div>
@@ -1960,7 +1960,7 @@ exports[`HTML Output should match combiners/allOfs/complex.json 1`] = `
                   <div></div>
                   <div style=\\"margin-left: 20px\\">
                     <div>
-                      <div class=\\"min-w-0\\">
+                      <div>
                         <div>
                           <div>
                             <div style=\\"width: 20px; height: 20px; left: -23.5px\\" role=\\"button\\"></div>
@@ -1977,7 +1977,7 @@ exports[`HTML Output should match combiners/allOfs/complex.json 1`] = `
                     <div>
                       <div style=\\"margin-left: 20px\\">
                         <div>
-                          <div class=\\"min-w-0\\">
+                          <div>
                             <div>
                               <div>
                                 <div style=\\"width: 20px; height: 20px; left: -23.5px\\" role=\\"button\\"></div>
@@ -1994,7 +1994,7 @@ exports[`HTML Output should match combiners/allOfs/complex.json 1`] = `
                         <div>
                           <div style=\\"margin-left: 20px\\">
                             <div>
-                              <div class=\\"min-w-0\\">
+                              <div>
                                 <div>
                                   <div>
                                     <div style=\\"width: 20px; height: 20px; left: -23.5px\\" role=\\"button\\"></div>
@@ -2011,7 +2011,7 @@ exports[`HTML Output should match combiners/allOfs/complex.json 1`] = `
                             <div>
                               <div style=\\"margin-left: 20px\\">
                                 <div>
-                                  <div class=\\"min-w-0\\">
+                                  <div>
                                     <div>
                                       <div>
                                         <div style=\\"width: 20px; height: 20px; left: -23.5px\\" role=\\"button\\"></div>
@@ -2065,7 +2065,7 @@ exports[`HTML Output should match combiners/allOfs/complex.json 1`] = `
                                   <div></div>
                                   <div style=\\"margin-left: 20px\\">
                                     <div>
-                                      <div class=\\"min-w-0\\">
+                                      <div>
                                         <div>
                                           <div>
                                             <div style=\\"width: 20px; height: 20px; left: -23.5px\\" role=\\"button\\"></div>
@@ -2082,7 +2082,7 @@ exports[`HTML Output should match combiners/allOfs/complex.json 1`] = `
                                     <div>
                                       <div style=\\"margin-left: 20px\\">
                                         <div>
-                                          <div class=\\"min-w-0\\">
+                                          <div>
                                             <div>
                                               <div>
                                                 <div
@@ -2102,7 +2102,7 @@ exports[`HTML Output should match combiners/allOfs/complex.json 1`] = `
                                         <div>
                                           <div style=\\"margin-left: 20px\\">
                                             <div>
-                                              <div class=\\"min-w-0\\">
+                                              <div>
                                                 <div>
                                                   <div>
                                                     <div
@@ -2122,7 +2122,7 @@ exports[`HTML Output should match combiners/allOfs/complex.json 1`] = `
                                             <div>
                                               <div style=\\"margin-left: 20px\\">
                                                 <div>
-                                                  <div class=\\"min-w-0\\">
+                                                  <div>
                                                     <div>
                                                       <div>
                                                         <div
@@ -2234,7 +2234,7 @@ exports[`HTML Output should match combiners/allOfs/complex.json 1`] = `
       <div></div>
       <div style=\\"margin-left: 20px\\">
         <div>
-          <div class=\\"min-w-0\\">
+          <div>
             <div>
               <div>
                 <div style=\\"width: 20px; height: 20px; left: -23.5px\\" role=\\"button\\"></div>
@@ -2251,7 +2251,7 @@ exports[`HTML Output should match combiners/allOfs/complex.json 1`] = `
         <div>
           <div style=\\"margin-left: 20px\\">
             <div>
-              <div class=\\"min-w-0\\">
+              <div>
                 <div>
                   <div>
                     <div style=\\"width: 20px; height: 20px; left: -23.5px\\" role=\\"button\\"></div>
@@ -2268,7 +2268,7 @@ exports[`HTML Output should match combiners/allOfs/complex.json 1`] = `
             <div>
               <div style=\\"margin-left: 20px\\">
                 <div>
-                  <div class=\\"min-w-0\\">
+                  <div>
                     <div>
                       <div>
                         <div style=\\"width: 20px; height: 20px; left: -23.5px\\" role=\\"button\\"></div>
@@ -2285,7 +2285,7 @@ exports[`HTML Output should match combiners/allOfs/complex.json 1`] = `
                 <div>
                   <div style=\\"margin-left: 20px\\">
                     <div>
-                      <div class=\\"min-w-0\\">
+                      <div>
                         <div>
                           <div>
                             <div style=\\"width: 20px; height: 20px; left: -23.5px\\" role=\\"button\\"></div>
@@ -2339,7 +2339,7 @@ exports[`HTML Output should match combiners/allOfs/complex.json 1`] = `
                       <div></div>
                       <div style=\\"margin-left: 20px\\">
                         <div>
-                          <div class=\\"min-w-0\\">
+                          <div>
                             <div>
                               <div>
                                 <div style=\\"width: 20px; height: 20px; left: -23.5px\\" role=\\"button\\"></div>
@@ -2356,7 +2356,7 @@ exports[`HTML Output should match combiners/allOfs/complex.json 1`] = `
                         <div>
                           <div style=\\"margin-left: 20px\\">
                             <div>
-                              <div class=\\"min-w-0\\">
+                              <div>
                                 <div>
                                   <div>
                                     <div style=\\"width: 20px; height: 20px; left: -23.5px\\" role=\\"button\\"></div>
@@ -2373,7 +2373,7 @@ exports[`HTML Output should match combiners/allOfs/complex.json 1`] = `
                             <div>
                               <div style=\\"margin-left: 20px\\">
                                 <div>
-                                  <div class=\\"min-w-0\\">
+                                  <div>
                                     <div>
                                       <div>
                                         <div style=\\"width: 20px; height: 20px; left: -23.5px\\" role=\\"button\\"></div>
@@ -2390,7 +2390,7 @@ exports[`HTML Output should match combiners/allOfs/complex.json 1`] = `
                                 <div>
                                   <div style=\\"margin-left: 20px\\">
                                     <div>
-                                      <div class=\\"min-w-0\\">
+                                      <div>
                                         <div>
                                           <div>
                                             <div style=\\"width: 20px; height: 20px; left: -23.5px\\" role=\\"button\\"></div>
@@ -2461,10 +2461,10 @@ exports[`HTML Output should match combiners/allOfs/complex.json 1`] = `
 `;
 
 exports[`HTML Output should match combiners/allOfs/todo-full.json 1`] = `
-"<div class=\\"sl-stack JsonSchemaViewer sl-flex sl-flex-col sl-items-stretch\\">
+"<div class=\\"JsonSchemaViewer\\">
   <div style=\\"margin-left: 20px\\">
     <div>
-      <div class=\\"min-w-0\\">
+      <div>
         <div>
           <div>
             <div style=\\"width: 20px; height: 20px; position: relative\\" role=\\"button\\"></div>
@@ -2480,7 +2480,7 @@ exports[`HTML Output should match combiners/allOfs/todo-full.json 1`] = `
     <div>
       <div style=\\"margin-left: 20px\\">
         <div>
-          <div class=\\"min-w-0\\">
+          <div>
             <div>
               <div>
                 <div>
@@ -2497,7 +2497,7 @@ exports[`HTML Output should match combiners/allOfs/todo-full.json 1`] = `
       <div></div>
       <div style=\\"margin-left: 20px\\">
         <div>
-          <div class=\\"min-w-0\\">
+          <div>
             <div>
               <div>
                 <div>
@@ -2518,7 +2518,7 @@ exports[`HTML Output should match combiners/allOfs/todo-full.json 1`] = `
       <div></div>
       <div style=\\"margin-left: 20px\\">
         <div>
-          <div class=\\"min-w-0\\">
+          <div>
             <div>
               <div>
                 <div>
@@ -2539,7 +2539,7 @@ exports[`HTML Output should match combiners/allOfs/todo-full.json 1`] = `
       <div></div>
       <div style=\\"margin-left: 20px\\">
         <div>
-          <div class=\\"min-w-0\\">
+          <div>
             <div>
               <div>
                 <div>
@@ -2560,7 +2560,7 @@ exports[`HTML Output should match combiners/allOfs/todo-full.json 1`] = `
       <div></div>
       <div style=\\"margin-left: 20px\\">
         <div>
-          <div class=\\"min-w-0\\">
+          <div>
             <div>
               <div>
                 <div>
@@ -2577,7 +2577,7 @@ exports[`HTML Output should match combiners/allOfs/todo-full.json 1`] = `
       <div></div>
       <div style=\\"margin-left: 20px\\">
         <div>
-          <div class=\\"min-w-0\\">
+          <div>
             <div>
               <div>
                 <div>
@@ -2594,7 +2594,7 @@ exports[`HTML Output should match combiners/allOfs/todo-full.json 1`] = `
       <div></div>
       <div style=\\"margin-left: 20px\\">
         <div>
-          <div class=\\"min-w-0\\">
+          <div>
             <div>
               <div>
                 <div style=\\"width: 20px; height: 20px; left: -23.5px\\" role=\\"button\\"></div>
@@ -2612,7 +2612,7 @@ exports[`HTML Output should match combiners/allOfs/todo-full.json 1`] = `
         <div>
           <div style=\\"margin-left: 20px\\">
             <div>
-              <div class=\\"min-w-0\\">
+              <div>
                 <div>
                   <div>
                     <div>
@@ -2630,7 +2630,7 @@ exports[`HTML Output should match combiners/allOfs/todo-full.json 1`] = `
           <div></div>
           <div style=\\"margin-left: 20px\\">
             <div>
-              <div class=\\"min-w-0\\">
+              <div>
                 <div>
                   <div>
                     <div>
@@ -2657,10 +2657,10 @@ exports[`HTML Output should match combiners/allOfs/todo-full.json 1`] = `
 `;
 
 exports[`HTML Output should match combiners/allOfs/todo-full-2.json 1`] = `
-"<div class=\\"sl-stack JsonSchemaViewer sl-flex sl-flex-col sl-items-stretch\\">
+"<div class=\\"JsonSchemaViewer\\">
   <div style=\\"margin-left: 20px\\">
     <div>
-      <div class=\\"min-w-0\\">
+      <div>
         <div>
           <div>
             <div style=\\"width: 20px; height: 20px; position: relative\\" role=\\"button\\"></div>
@@ -2676,7 +2676,7 @@ exports[`HTML Output should match combiners/allOfs/todo-full-2.json 1`] = `
     <div>
       <div style=\\"margin-left: 20px\\">
         <div>
-          <div class=\\"min-w-0\\">
+          <div>
             <div>
               <div>
                 <div>
@@ -2692,7 +2692,7 @@ exports[`HTML Output should match combiners/allOfs/todo-full-2.json 1`] = `
       <div></div>
       <div style=\\"margin-left: 20px\\">
         <div>
-          <div class=\\"min-w-0\\">
+          <div>
             <div>
               <div>
                 <div>
@@ -2713,7 +2713,7 @@ exports[`HTML Output should match combiners/allOfs/todo-full-2.json 1`] = `
       <div></div>
       <div style=\\"margin-left: 20px\\">
         <div>
-          <div class=\\"min-w-0\\">
+          <div>
             <div>
               <div>
                 <div>
@@ -2734,7 +2734,7 @@ exports[`HTML Output should match combiners/allOfs/todo-full-2.json 1`] = `
       <div></div>
       <div style=\\"margin-left: 20px\\">
         <div>
-          <div class=\\"min-w-0\\">
+          <div>
             <div>
               <div>
                 <div>
@@ -2751,7 +2751,7 @@ exports[`HTML Output should match combiners/allOfs/todo-full-2.json 1`] = `
       <div></div>
       <div style=\\"margin-left: 20px\\">
         <div>
-          <div class=\\"min-w-0\\">
+          <div>
             <div>
               <div>
                 <div>
@@ -2772,10 +2772,10 @@ exports[`HTML Output should match combiners/allOfs/todo-full-2.json 1`] = `
 `;
 
 exports[`HTML Output should match combiners/allOfs/with-type.json 1`] = `
-"<div class=\\"sl-stack JsonSchemaViewer sl-flex sl-flex-col sl-items-stretch\\">
+"<div class=\\"JsonSchemaViewer\\">
   <div style=\\"margin-left: 20px\\">
     <div>
-      <div class=\\"min-w-0\\">
+      <div>
         <div>
           <div>
             <div style=\\"width: 20px; height: 20px; position: relative\\" role=\\"button\\"></div>
@@ -2791,7 +2791,7 @@ exports[`HTML Output should match combiners/allOfs/with-type.json 1`] = `
     <div>
       <div style=\\"margin-left: 20px\\">
         <div>
-          <div class=\\"min-w-0\\">
+          <div>
             <div>
               <div>
                 <div style=\\"width: 20px; height: 20px; left: -23.5px\\" role=\\"button\\"></div>
@@ -2810,7 +2810,7 @@ exports[`HTML Output should match combiners/allOfs/with-type.json 1`] = `
         <div>
           <div style=\\"margin-left: 20px\\">
             <div>
-              <div class=\\"min-w-0\\">
+              <div>
                 <div>
                   <div>
                     <div>
@@ -2833,7 +2833,7 @@ exports[`HTML Output should match combiners/allOfs/with-type.json 1`] = `
           <div></div>
           <div style=\\"margin-left: 20px\\">
             <div>
-              <div class=\\"min-w-0\\">
+              <div>
                 <div>
                   <div>
                     <div>
@@ -2855,7 +2855,7 @@ exports[`HTML Output should match combiners/allOfs/with-type.json 1`] = `
           <div></div>
           <div style=\\"margin-left: 20px\\">
             <div>
-              <div class=\\"min-w-0\\">
+              <div>
                 <div>
                   <div>
                     <div>
@@ -2871,7 +2871,7 @@ exports[`HTML Output should match combiners/allOfs/with-type.json 1`] = `
           <div></div>
           <div style=\\"margin-left: 20px\\">
             <div>
-              <div class=\\"min-w-0\\">
+              <div>
                 <div>
                   <div>
                     <div>
@@ -2887,7 +2887,7 @@ exports[`HTML Output should match combiners/allOfs/with-type.json 1`] = `
           <div></div>
           <div style=\\"margin-left: 20px\\">
             <div>
-              <div class=\\"min-w-0\\">
+              <div>
                 <div>
                   <div>
                     <div>
@@ -2903,7 +2903,7 @@ exports[`HTML Output should match combiners/allOfs/with-type.json 1`] = `
           <div></div>
           <div style=\\"margin-left: 20px\\">
             <div>
-              <div class=\\"min-w-0\\">
+              <div>
                 <div>
                   <div>
                     <div>
@@ -2922,7 +2922,7 @@ exports[`HTML Output should match combiners/allOfs/with-type.json 1`] = `
       <div></div>
       <div style=\\"margin-left: 20px\\">
         <div>
-          <div class=\\"min-w-0\\">
+          <div>
             <div>
               <div>
                 <div style=\\"width: 20px; height: 20px; left: -23.5px\\" role=\\"button\\"></div>
@@ -2942,7 +2942,7 @@ exports[`HTML Output should match combiners/allOfs/with-type.json 1`] = `
         <div>
           <div style=\\"margin-left: 20px\\">
             <div>
-              <div class=\\"min-w-0\\">
+              <div>
                 <div>
                   <div>
                     <div>
@@ -2963,7 +2963,7 @@ exports[`HTML Output should match combiners/allOfs/with-type.json 1`] = `
           <div></div>
           <div style=\\"margin-left: 20px\\">
             <div>
-              <div class=\\"min-w-0\\">
+              <div>
                 <div>
                   <div>
                     <div>
@@ -2984,7 +2984,7 @@ exports[`HTML Output should match combiners/allOfs/with-type.json 1`] = `
           <div></div>
           <div style=\\"margin-left: 20px\\">
             <div>
-              <div class=\\"min-w-0\\">
+              <div>
                 <div>
                   <div>
                     <div>
@@ -3000,7 +3000,7 @@ exports[`HTML Output should match combiners/allOfs/with-type.json 1`] = `
           <div></div>
           <div style=\\"margin-left: 20px\\">
             <div>
-              <div class=\\"min-w-0\\">
+              <div>
                 <div>
                   <div>
                     <div>
@@ -3016,7 +3016,7 @@ exports[`HTML Output should match combiners/allOfs/with-type.json 1`] = `
           <div></div>
           <div style=\\"margin-left: 20px\\">
             <div>
-              <div class=\\"min-w-0\\">
+              <div>
                 <div>
                   <div>
                     <div>
@@ -3032,7 +3032,7 @@ exports[`HTML Output should match combiners/allOfs/with-type.json 1`] = `
           <div></div>
           <div style=\\"margin-left: 20px\\">
             <div>
-              <div class=\\"min-w-0\\">
+              <div>
                 <div>
                   <div>
                     <div>
@@ -3055,10 +3055,10 @@ exports[`HTML Output should match combiners/allOfs/with-type.json 1`] = `
 `;
 
 exports[`HTML Output should match combiners/oneof-with-array-type.json 1`] = `
-"<div class=\\"sl-stack JsonSchemaViewer sl-flex sl-flex-col sl-items-stretch\\">
+"<div class=\\"JsonSchemaViewer\\">
   <div style=\\"margin-left: 20px\\">
     <div>
-      <div class=\\"min-w-0\\">
+      <div>
         <div>
           <div>
             <div style=\\"width: 20px; height: 20px; position: relative\\" role=\\"button\\"></div>
@@ -3074,7 +3074,7 @@ exports[`HTML Output should match combiners/oneof-with-array-type.json 1`] = `
     <div>
       <div style=\\"margin-left: 20px\\">
         <div>
-          <div class=\\"min-w-0\\">
+          <div>
             <div>
               <div>
                 <div style=\\"width: 20px; height: 20px; left: -23.5px\\" role=\\"button\\"></div>
@@ -3090,7 +3090,7 @@ exports[`HTML Output should match combiners/oneof-with-array-type.json 1`] = `
         <div>
           <div style=\\"margin-left: 20px\\">
             <div>
-              <div class=\\"min-w-0\\">
+              <div>
                 <div>
                   <div>
                     <div>
@@ -3110,7 +3110,7 @@ exports[`HTML Output should match combiners/oneof-with-array-type.json 1`] = `
           <div></div>
           <div style=\\"margin-left: 20px\\">
             <div>
-              <div class=\\"min-w-0\\">
+              <div>
                 <div>
                   <div>
                     <div>
@@ -3128,7 +3128,7 @@ exports[`HTML Output should match combiners/oneof-with-array-type.json 1`] = `
       <div></div>
       <div style=\\"margin-left: 20px\\">
         <div>
-          <div class=\\"min-w-0\\">
+          <div>
             <div>
               <div>
                 <div style=\\"width: 20px; height: 20px; left: -23.5px\\" role=\\"button\\"></div>
@@ -3145,7 +3145,7 @@ exports[`HTML Output should match combiners/oneof-with-array-type.json 1`] = `
         <div>
           <div style=\\"margin-left: 20px\\">
             <div>
-              <div class=\\"min-w-0\\">
+              <div>
                 <div>
                   <div>
                     <div>
@@ -3161,7 +3161,7 @@ exports[`HTML Output should match combiners/oneof-with-array-type.json 1`] = `
           <div></div>
           <div style=\\"margin-left: 20px\\">
             <div>
-              <div class=\\"min-w-0\\">
+              <div>
                 <div>
                   <div>
                     <div>
@@ -3177,7 +3177,7 @@ exports[`HTML Output should match combiners/oneof-with-array-type.json 1`] = `
           <div></div>
           <div style=\\"margin-left: 20px\\">
             <div>
-              <div class=\\"min-w-0\\">
+              <div>
                 <div>
                   <div>
                     <div>
@@ -3199,10 +3199,10 @@ exports[`HTML Output should match combiners/oneof-with-array-type.json 1`] = `
 `;
 
 exports[`HTML Output should match default-schema.json 1`] = `
-"<div class=\\"sl-stack JsonSchemaViewer sl-flex sl-flex-col sl-items-stretch\\">
+"<div class=\\"JsonSchemaViewer\\">
   <div style=\\"margin-left: 20px\\">
     <div>
-      <div class=\\"min-w-0\\">
+      <div>
         <div>
           <div>
             <div style=\\"width: 20px; height: 20px; position: relative\\" role=\\"button\\"></div>
@@ -3218,7 +3218,7 @@ exports[`HTML Output should match default-schema.json 1`] = `
     <div>
       <div style=\\"margin-left: 20px\\">
         <div>
-          <div class=\\"min-w-0\\">
+          <div>
             <div>
               <div>
                 <div>
@@ -3252,7 +3252,7 @@ exports[`HTML Output should match default-schema.json 1`] = `
       <div></div>
       <div style=\\"margin-left: 20px\\">
         <div>
-          <div class=\\"min-w-0\\">
+          <div>
             <div>
               <div>
                 <div>
@@ -3289,7 +3289,7 @@ exports[`HTML Output should match default-schema.json 1`] = `
       <div></div>
       <div style=\\"margin-left: 20px\\">
         <div>
-          <div class=\\"min-w-0\\">
+          <div>
             <div>
               <div>
                 <div>
@@ -3312,7 +3312,7 @@ exports[`HTML Output should match default-schema.json 1`] = `
       <div></div>
       <div style=\\"margin-left: 20px\\">
         <div>
-          <div class=\\"min-w-0\\">
+          <div>
             <div>
               <div>
                 <div>
@@ -3344,7 +3344,7 @@ exports[`HTML Output should match default-schema.json 1`] = `
       <div></div>
       <div style=\\"margin-left: 20px\\">
         <div>
-          <div class=\\"min-w-0\\">
+          <div>
             <div>
               <div>
                 <div>
@@ -3372,7 +3372,7 @@ exports[`HTML Output should match default-schema.json 1`] = `
       <div></div>
       <div style=\\"margin-left: 20px\\">
         <div>
-          <div class=\\"min-w-0\\">
+          <div>
             <div>
               <div>
                 <div style=\\"width: 20px; height: 20px; left: -23.5px\\" role=\\"button\\"></div>
@@ -3389,7 +3389,7 @@ exports[`HTML Output should match default-schema.json 1`] = `
         <div>
           <div style=\\"margin-left: 20px\\">
             <div>
-              <div class=\\"min-w-0\\">
+              <div>
                 <div>
                   <div>
                     <div style=\\"width: 20px; height: 20px; left: -23.5px\\" role=\\"button\\"></div>
@@ -3409,7 +3409,7 @@ exports[`HTML Output should match default-schema.json 1`] = `
             <div>
               <div style=\\"margin-left: 20px\\">
                 <div>
-                  <div class=\\"min-w-0\\">
+                  <div>
                     <div>
                       <div>
                         <div>
@@ -3426,7 +3426,7 @@ exports[`HTML Output should match default-schema.json 1`] = `
               <div></div>
               <div style=\\"margin-left: 20px\\">
                 <div>
-                  <div class=\\"min-w-0\\">
+                  <div>
                     <div>
                       <div>
                         <div>
@@ -3445,7 +3445,7 @@ exports[`HTML Output should match default-schema.json 1`] = `
           <div></div>
           <div style=\\"margin-left: 20px\\">
             <div>
-              <div class=\\"min-w-0\\">
+              <div>
                 <div>
                   <div>
                     <div style=\\"top: -9px; height: 1px\\"><div>and/or</div></div>
@@ -3461,7 +3461,7 @@ exports[`HTML Output should match default-schema.json 1`] = `
       <div></div>
       <div style=\\"margin-left: 20px\\">
         <div>
-          <div class=\\"min-w-0\\">
+          <div>
             <div>
               <div>
                 <div style=\\"width: 20px; height: 20px; left: -23.5px\\" role=\\"button\\"></div>
@@ -3482,7 +3482,7 @@ exports[`HTML Output should match default-schema.json 1`] = `
         <div>
           <div style=\\"margin-left: 20px\\">
             <div>
-              <div class=\\"min-w-0\\">
+              <div>
                 <div>
                   <div>
                     <div>
@@ -3500,7 +3500,7 @@ exports[`HTML Output should match default-schema.json 1`] = `
       <div></div>
       <div style=\\"margin-left: 20px\\">
         <div>
-          <div class=\\"min-w-0\\">
+          <div>
             <div>
               <div>
                 <div style=\\"width: 20px; height: 20px; left: -23.5px\\" role=\\"button\\"></div>
@@ -3521,7 +3521,7 @@ exports[`HTML Output should match default-schema.json 1`] = `
         <div>
           <div style=\\"margin-left: 20px\\">
             <div>
-              <div class=\\"min-w-0\\">
+              <div>
                 <div>
                   <div>
                     <div>
@@ -3539,7 +3539,7 @@ exports[`HTML Output should match default-schema.json 1`] = `
       <div></div>
       <div style=\\"margin-left: 20px\\">
         <div>
-          <div class=\\"min-w-0\\">
+          <div>
             <div>
               <div>
                 <div>
@@ -3556,7 +3556,7 @@ exports[`HTML Output should match default-schema.json 1`] = `
       <div></div>
       <div style=\\"margin-left: 20px\\">
         <div>
-          <div class=\\"min-w-0\\">
+          <div>
             <div>
               <div>
                 <div>
@@ -3573,7 +3573,7 @@ exports[`HTML Output should match default-schema.json 1`] = `
       <div></div>
       <div style=\\"margin-left: 20px\\">
         <div>
-          <div class=\\"min-w-0\\">
+          <div>
             <div>
               <div>
                 <div>
@@ -3594,10 +3594,10 @@ exports[`HTML Output should match default-schema.json 1`] = `
 `;
 
 exports[`HTML Output should match formats-schema.json 1`] = `
-"<div class=\\"sl-stack JsonSchemaViewer sl-flex sl-flex-col sl-items-stretch\\">
+"<div class=\\"JsonSchemaViewer\\">
   <div style=\\"margin-left: 20px\\">
     <div>
-      <div class=\\"min-w-0\\">
+      <div>
         <div>
           <div>
             <div style=\\"width: 20px; height: 20px; position: relative\\" role=\\"button\\"></div>
@@ -3613,7 +3613,7 @@ exports[`HTML Output should match formats-schema.json 1`] = `
     <div>
       <div style=\\"margin-left: 20px\\">
         <div>
-          <div class=\\"min-w-0\\">
+          <div>
             <div>
               <div>
                 <div>
@@ -3636,7 +3636,7 @@ exports[`HTML Output should match formats-schema.json 1`] = `
       <div></div>
       <div style=\\"margin-left: 20px\\">
         <div>
-          <div class=\\"min-w-0\\">
+          <div>
             <div>
               <div>
                 <div>
@@ -3652,7 +3652,7 @@ exports[`HTML Output should match formats-schema.json 1`] = `
       <div></div>
       <div style=\\"margin-left: 20px\\">
         <div>
-          <div class=\\"min-w-0\\">
+          <div>
             <div>
               <div>
                 <div>
@@ -3669,7 +3669,7 @@ exports[`HTML Output should match formats-schema.json 1`] = `
       <div></div>
       <div style=\\"margin-left: 20px\\">
         <div>
-          <div class=\\"min-w-0\\">
+          <div>
             <div>
               <div>
                 <div>
@@ -3685,7 +3685,7 @@ exports[`HTML Output should match formats-schema.json 1`] = `
       <div></div>
       <div style=\\"margin-left: 20px\\">
         <div>
-          <div class=\\"min-w-0\\">
+          <div>
             <div>
               <div>
                 <div style=\\"width: 20px; height: 20px; left: -23.5px\\" role=\\"button\\"></div>
@@ -3707,7 +3707,7 @@ exports[`HTML Output should match formats-schema.json 1`] = `
         <div>
           <div style=\\"margin-left: 20px\\">
             <div>
-              <div class=\\"min-w-0\\">
+              <div>
                 <div>
                   <div>
                     <div>
@@ -3729,10 +3729,10 @@ exports[`HTML Output should match formats-schema.json 1`] = `
 `;
 
 exports[`HTML Output should match references/base.json 1`] = `
-"<div class=\\"sl-stack JsonSchemaViewer sl-flex sl-flex-col sl-items-stretch\\">
+"<div class=\\"JsonSchemaViewer\\">
   <div style=\\"margin-left: 20px\\">
     <div>
-      <div class=\\"min-w-0\\">
+      <div>
         <div>
           <div>
             <div style=\\"width: 20px; height: 20px; position: relative\\" role=\\"button\\"></div>
@@ -3748,7 +3748,7 @@ exports[`HTML Output should match references/base.json 1`] = `
     <div>
       <div style=\\"margin-left: 20px\\">
         <div>
-          <div class=\\"min-w-0\\">
+          <div>
             <div>
               <div>
                 <div style=\\"width: 20px; height: 20px; left: -23.5px\\" role=\\"button\\"></div>
@@ -3765,7 +3765,7 @@ exports[`HTML Output should match references/base.json 1`] = `
         <div>
           <div style=\\"margin-left: 20px\\">
             <div>
-              <div class=\\"min-w-0\\">
+              <div>
                 <div>
                   <div>
                     <div>
@@ -3782,7 +3782,7 @@ exports[`HTML Output should match references/base.json 1`] = `
           <div></div>
           <div style=\\"margin-left: 20px\\">
             <div>
-              <div class=\\"min-w-0\\">
+              <div>
                 <div>
                   <div>
                     <div>
@@ -3799,7 +3799,7 @@ exports[`HTML Output should match references/base.json 1`] = `
           <div></div>
           <div style=\\"margin-left: 20px\\">
             <div>
-              <div class=\\"min-w-0\\">
+              <div>
                 <div>
                   <div>
                     <div>
@@ -3818,7 +3818,7 @@ exports[`HTML Output should match references/base.json 1`] = `
       <div></div>
       <div style=\\"margin-left: 20px\\">
         <div>
-          <div class=\\"min-w-0\\">
+          <div>
             <div>
               <div>
                 <div style=\\"width: 20px; height: 20px; left: -23.5px\\" role=\\"button\\"></div>
@@ -3835,7 +3835,7 @@ exports[`HTML Output should match references/base.json 1`] = `
         <div>
           <div style=\\"margin-left: 20px\\">
             <div>
-              <div class=\\"min-w-0\\">
+              <div>
                 <div>
                   <div>
                     <div>
@@ -3852,7 +3852,7 @@ exports[`HTML Output should match references/base.json 1`] = `
           <div></div>
           <div style=\\"margin-left: 20px\\">
             <div>
-              <div class=\\"min-w-0\\">
+              <div>
                 <div>
                   <div>
                     <div>
@@ -3869,7 +3869,7 @@ exports[`HTML Output should match references/base.json 1`] = `
           <div></div>
           <div style=\\"margin-left: 20px\\">
             <div>
-              <div class=\\"min-w-0\\">
+              <div>
                 <div>
                   <div>
                     <div>
@@ -3892,10 +3892,10 @@ exports[`HTML Output should match references/base.json 1`] = `
 `;
 
 exports[`HTML Output should match references/nullish.json 1`] = `
-"<div class=\\"sl-stack JsonSchemaViewer sl-flex sl-flex-col sl-items-stretch\\">
+"<div class=\\"JsonSchemaViewer\\">
   <div style=\\"margin-left: 20px\\">
     <div>
-      <div class=\\"min-w-0\\">
+      <div>
         <div>
           <div>
             <div style=\\"width: 20px; height: 20px; position: relative\\" role=\\"button\\"></div>
@@ -3931,10 +3931,10 @@ exports[`HTML Output should match references/nullish.json 1`] = `
 `;
 
 exports[`HTML Output should match tickets.schema.json 1`] = `
-"<div class=\\"sl-stack JsonSchemaViewer sl-flex sl-flex-col sl-items-stretch\\">
+"<div class=\\"JsonSchemaViewer\\">
   <div style=\\"margin-left: 20px\\">
     <div>
-      <div class=\\"min-w-0\\">
+      <div>
         <div>
           <div>
             <div style=\\"width: 20px; height: 20px; position: relative\\" role=\\"button\\"></div>
@@ -3990,7 +3990,7 @@ exports[`HTML Output should match tickets.schema.json 1`] = `
       <div></div>
       <div style=\\"margin-left: 20px\\">
         <div>
-          <div class=\\"min-w-0\\">
+          <div>
             <div>
               <div>
                 <div>
@@ -4011,7 +4011,7 @@ exports[`HTML Output should match tickets.schema.json 1`] = `
       <div></div>
       <div style=\\"margin-left: 20px\\">
         <div>
-          <div class=\\"min-w-0\\">
+          <div>
             <div>
               <div>
                 <div style=\\"width: 20px; height: 20px; left: -23.5px\\" role=\\"button\\"></div>
@@ -4031,7 +4031,7 @@ exports[`HTML Output should match tickets.schema.json 1`] = `
         <div>
           <div style=\\"margin-left: 20px\\">
             <div>
-              <div class=\\"min-w-0\\">
+              <div>
                 <div>
                   <div>
                     <div>
@@ -4066,7 +4066,7 @@ exports[`HTML Output should match tickets.schema.json 1`] = `
           <div></div>
           <div style=\\"margin-left: 20px\\">
             <div>
-              <div class=\\"min-w-0\\">
+              <div>
                 <div>
                   <div>
                     <div style=\\"width: 20px; height: 20px; left: -23.5px\\" role=\\"button\\"></div>
@@ -4088,7 +4088,7 @@ exports[`HTML Output should match tickets.schema.json 1`] = `
             <div>
               <div style=\\"margin-left: 20px\\">
                 <div>
-                  <div class=\\"min-w-0\\">
+                  <div>
                     <div>
                       <div>
                         <div>
@@ -4105,7 +4105,7 @@ exports[`HTML Output should match tickets.schema.json 1`] = `
               <div></div>
               <div style=\\"margin-left: 20px\\">
                 <div>
-                  <div class=\\"min-w-0\\">
+                  <div>
                     <div>
                       <div>
                         <div style=\\"width: 20px; height: 20px; left: -23.5px\\" role=\\"button\\"></div>
@@ -4127,7 +4127,7 @@ exports[`HTML Output should match tickets.schema.json 1`] = `
                 <div>
                   <div style=\\"margin-left: 20px\\">
                     <div>
-                      <div class=\\"min-w-0\\">
+                      <div>
                         <div>
                           <div>
                             <div>
@@ -4154,7 +4154,7 @@ exports[`HTML Output should match tickets.schema.json 1`] = `
                   <div></div>
                   <div style=\\"margin-left: 20px\\">
                     <div>
-                      <div class=\\"min-w-0\\">
+                      <div>
                         <div>
                           <div>
                             <div>
@@ -4179,7 +4179,7 @@ exports[`HTML Output should match tickets.schema.json 1`] = `
                   <div></div>
                   <div style=\\"margin-left: 20px\\">
                     <div>
-                      <div class=\\"min-w-0\\">
+                      <div>
                         <div>
                           <div>
                             <div>
@@ -4200,7 +4200,7 @@ exports[`HTML Output should match tickets.schema.json 1`] = `
                   <div></div>
                   <div style=\\"margin-left: 20px\\">
                     <div>
-                      <div class=\\"min-w-0\\">
+                      <div>
                         <div>
                           <div>
                             <div style=\\"width: 20px; height: 20px; left: -23.5px\\" role=\\"button\\"></div>
@@ -4218,7 +4218,7 @@ exports[`HTML Output should match tickets.schema.json 1`] = `
                     <div>
                       <div style=\\"margin-left: 20px\\">
                         <div>
-                          <div class=\\"min-w-0\\">
+                          <div>
                             <div>
                               <div>
                                 <div>
@@ -4234,7 +4234,7 @@ exports[`HTML Output should match tickets.schema.json 1`] = `
                       <div></div>
                       <div style=\\"margin-left: 20px\\">
                         <div>
-                          <div class=\\"min-w-0\\">
+                          <div>
                             <div>
                               <div>
                                 <div>
@@ -4250,7 +4250,7 @@ exports[`HTML Output should match tickets.schema.json 1`] = `
                       <div></div>
                       <div style=\\"margin-left: 20px\\">
                         <div>
-                          <div class=\\"min-w-0\\">
+                          <div>
                             <div>
                               <div>
                                 <div>
@@ -4283,7 +4283,7 @@ exports[`HTML Output should match tickets.schema.json 1`] = `
                       <div></div>
                       <div style=\\"margin-left: 20px\\">
                         <div>
-                          <div class=\\"min-w-0\\">
+                          <div>
                             <div>
                               <div>
                                 <div>

--- a/src/__tests__/index.spec.tsx
+++ b/src/__tests__/index.spec.tsx
@@ -236,10 +236,10 @@ describe('Expanded depth', () => {
         const wrapper = mountWithAutoUnmount(<JsonSchemaViewer schema={schema} defaultExpandedDepth={-1} />);
 
         expect(dumpDom(wrapper.getElement())).toMatchInlineSnapshot(`
-          "<div class=\\"sl-stack JsonSchemaViewer sl-flex sl-flex-col sl-items-stretch\\">
+          "<div class=\\"JsonSchemaViewer\\">
             <div style=\\"margin-left: 20px\\">
               <div>
-                <div class=\\"min-w-0\\">
+                <div>
                   <div>
                     <div>
                       <div style=\\"width: 20px; height: 20px; position: relative\\" role=\\"button\\"></div>
@@ -262,10 +262,10 @@ describe('Expanded depth', () => {
         const wrapper = mountWithAutoUnmount(<JsonSchemaViewer schema={schema} defaultExpandedDepth={0} />);
 
         expect(dumpDom(wrapper.getElement())).toMatchInlineSnapshot(`
-          "<div class=\\"sl-stack JsonSchemaViewer sl-flex sl-flex-col sl-items-stretch\\">
+          "<div class=\\"JsonSchemaViewer\\">
             <div style=\\"margin-left: 20px\\">
               <div>
-                <div class=\\"min-w-0\\">
+                <div>
                   <div>
                     <div>
                       <div style=\\"width: 20px; height: 20px; position: relative\\" role=\\"button\\"></div>
@@ -281,7 +281,7 @@ describe('Expanded depth', () => {
               <div>
                 <div style=\\"margin-left: 20px\\">
                   <div>
-                    <div class=\\"min-w-0\\">
+                    <div>
                       <div>
                         <div>
                           <div style=\\"width: 20px; height: 20px; left: -23.5px\\" role=\\"button\\"></div>
@@ -307,10 +307,10 @@ describe('Expanded depth', () => {
         const wrapper = mountWithAutoUnmount(<JsonSchemaViewer schema={schema} defaultExpandedDepth={1} />);
 
         expect(dumpDom(wrapper.getElement())).toMatchInlineSnapshot(`
-          "<div class=\\"sl-stack JsonSchemaViewer sl-flex sl-flex-col sl-items-stretch\\">
+          "<div class=\\"JsonSchemaViewer\\">
             <div style=\\"margin-left: 20px\\">
               <div>
-                <div class=\\"min-w-0\\">
+                <div>
                   <div>
                     <div>
                       <div style=\\"width: 20px; height: 20px; position: relative\\" role=\\"button\\"></div>
@@ -326,7 +326,7 @@ describe('Expanded depth', () => {
               <div>
                 <div style=\\"margin-left: 20px\\">
                   <div>
-                    <div class=\\"min-w-0\\">
+                    <div>
                       <div>
                         <div>
                           <div style=\\"width: 20px; height: 20px; left: -23.5px\\" role=\\"button\\"></div>
@@ -343,7 +343,7 @@ describe('Expanded depth', () => {
                   <div>
                     <div style=\\"margin-left: 20px\\">
                       <div>
-                        <div class=\\"min-w-0\\">
+                        <div>
                           <div>
                             <div>
                               <div style=\\"width: 20px; height: 20px; left: -23.5px\\" role=\\"button\\"></div>
@@ -405,10 +405,10 @@ describe('Expanded depth', () => {
         const wrapper = mountWithAutoUnmount(<JsonSchemaViewer schema={schema} defaultExpandedDepth={-1} />);
 
         expect(dumpDom(wrapper.getElement())).toMatchInlineSnapshot(`
-          "<div class=\\"sl-stack JsonSchemaViewer sl-flex sl-flex-col sl-items-stretch\\">
+          "<div class=\\"JsonSchemaViewer\\">
             <div style=\\"margin-left: 20px\\">
               <div>
-                <div class=\\"min-w-0\\">
+                <div>
                   <div>
                     <div>
                       <div style=\\"width: 20px; height: 20px; position: relative\\" role=\\"button\\"></div>
@@ -431,10 +431,10 @@ describe('Expanded depth', () => {
         const wrapper = mountWithAutoUnmount(<JsonSchemaViewer schema={schema} defaultExpandedDepth={0} />);
 
         expect(dumpDom(wrapper.getElement())).toMatchInlineSnapshot(`
-          "<div class=\\"sl-stack JsonSchemaViewer sl-flex sl-flex-col sl-items-stretch\\">
+          "<div class=\\"JsonSchemaViewer\\">
             <div style=\\"margin-left: 20px\\">
               <div>
-                <div class=\\"min-w-0\\">
+                <div>
                   <div>
                     <div>
                       <div style=\\"width: 20px; height: 20px; position: relative\\" role=\\"button\\"></div>
@@ -450,7 +450,7 @@ describe('Expanded depth', () => {
               <div>
                 <div style=\\"margin-left: 20px\\">
                   <div>
-                    <div class=\\"min-w-0\\">
+                    <div>
                       <div>
                         <div>
                           <div>
@@ -466,7 +466,7 @@ describe('Expanded depth', () => {
                 <div></div>
                 <div style=\\"margin-left: 20px\\">
                   <div>
-                    <div class=\\"min-w-0\\">
+                    <div>
                       <div>
                         <div>
                           <div style=\\"width: 20px; height: 20px; left: -23.5px\\" role=\\"button\\"></div>
@@ -492,10 +492,10 @@ describe('Expanded depth', () => {
         const wrapper = mountWithAutoUnmount(<JsonSchemaViewer schema={schema} defaultExpandedDepth={1} />);
 
         expect(dumpDom(wrapper.getElement())).toMatchInlineSnapshot(`
-          "<div class=\\"sl-stack JsonSchemaViewer sl-flex sl-flex-col sl-items-stretch\\">
+          "<div class=\\"JsonSchemaViewer\\">
             <div style=\\"margin-left: 20px\\">
               <div>
-                <div class=\\"min-w-0\\">
+                <div>
                   <div>
                     <div>
                       <div style=\\"width: 20px; height: 20px; position: relative\\" role=\\"button\\"></div>
@@ -511,7 +511,7 @@ describe('Expanded depth', () => {
               <div>
                 <div style=\\"margin-left: 20px\\">
                   <div>
-                    <div class=\\"min-w-0\\">
+                    <div>
                       <div>
                         <div>
                           <div>
@@ -527,7 +527,7 @@ describe('Expanded depth', () => {
                 <div></div>
                 <div style=\\"margin-left: 20px\\">
                   <div>
-                    <div class=\\"min-w-0\\">
+                    <div>
                       <div>
                         <div>
                           <div style=\\"width: 20px; height: 20px; left: -23.5px\\" role=\\"button\\"></div>
@@ -544,7 +544,7 @@ describe('Expanded depth', () => {
                   <div>
                     <div style=\\"margin-left: 20px\\">
                       <div>
-                        <div class=\\"min-w-0\\">
+                        <div>
                           <div>
                             <div>
                               <div>
@@ -560,7 +560,7 @@ describe('Expanded depth', () => {
                     <div></div>
                     <div style=\\"margin-left: 20px\\">
                       <div>
-                        <div class=\\"min-w-0\\">
+                        <div>
                           <div>
                             <div>
                               <div>
@@ -633,10 +633,10 @@ describe('Expanded depth', () => {
         const wrapper = mountWithAutoUnmount(<JsonSchemaViewer schema={schema} defaultExpandedDepth={-1} />);
 
         expect(dumpDom(wrapper.getElement())).toMatchInlineSnapshot(`
-          "<div class=\\"sl-stack JsonSchemaViewer sl-flex sl-flex-col sl-items-stretch\\">
+          "<div class=\\"JsonSchemaViewer\\">
             <div style=\\"margin-left: 20px\\">
               <div>
-                <div class=\\"min-w-0\\">
+                <div>
                   <div>
                     <div>
                       <div style=\\"width: 20px; height: 20px; position: relative\\" role=\\"button\\"></div>
@@ -688,10 +688,10 @@ describe('$ref resolving', () => {
     };
 
     expect(dumpDom(<JsonSchemaViewer schema={schema} />)).toMatchInlineSnapshot(`
-      "<div class=\\"sl-stack JsonSchemaViewer sl-flex sl-flex-col sl-items-stretch\\">
+      "<div class=\\"JsonSchemaViewer\\">
         <div style=\\"margin-left: 20px\\">
           <div>
-            <div class=\\"min-w-0\\">
+            <div>
               <div>
                 <div>
                   <div><span>string</span></div>
@@ -715,7 +715,7 @@ describe('$ref resolving', () => {
     };
 
     expect(dumpDom(<JsonSchemaViewer schema={schema} />)).toMatchInlineSnapshot(`
-      "<div class=\\"sl-stack JsonSchemaViewer sl-flex sl-flex-col sl-items-stretch\\">
+      "<div class=\\"JsonSchemaViewer\\">
         <div style=\\"margin-left: 20px\\">
           <div>
             <div>

--- a/src/components/JsonSchemaViewer.tsx
+++ b/src/components/JsonSchemaViewer.tsx
@@ -1,12 +1,12 @@
 import { isRegularNode, SchemaTree as JsonSchemaTree, SchemaTreeRefDereferenceFn } from '@stoplight/json-schema-tree';
-import { Box, VStack } from '@stoplight/mosaic';
+import { Box } from '@stoplight/mosaic';
 import { ErrorBoundaryForwardedProps, FallbackProps, withErrorBoundary } from '@stoplight/react-error-boundary';
 import cn from 'classnames';
 import type { JSONSchema4 } from 'json-schema';
 import * as React from 'react';
 
 import { JSVOptions, JSVOptionsContextProvider } from '../contexts';
-import { SchemaRow } from './SchemaRow';
+import { ChildStack } from './shared/ChildStack';
 
 export type JsonSchemaProps = Partial<JSVOptions> & {
   schema: JSONSchema4;
@@ -62,11 +62,11 @@ const JsonSchemaViewerComponent: React.FC<JsonSchemaProps & ErrorBoundaryForward
 
   return (
     <JSVOptionsContextProvider value={options}>
-      <VStack divider className={cn(className, 'JsonSchemaViewer')}>
-        {jsonSchemaTreeRoot.children.map(childJsonSchemaNode => (
-          <SchemaRow key={childJsonSchemaNode.id} schemaNode={childJsonSchemaNode} nestingLevel={0} />
-        ))}
-      </VStack>
+      <ChildStack
+        childNodes={jsonSchemaTreeRoot.children}
+        currentNestingLevel={-1}
+        className={cn(className, 'JsonSchemaViewer')}
+      />
     </JSVOptionsContextProvider>
   );
 };

--- a/src/components/SchemaRow.tsx
+++ b/src/components/SchemaRow.tsx
@@ -7,7 +7,8 @@ import {
   SchemaNode,
   SchemaNodeKind,
 } from '@stoplight/json-schema-tree';
-import { Box, Flex, Icon, VStack } from '@stoplight/mosaic';
+import { Icon } from '@stoplight/mosaic';
+import cn from 'classnames';
 import * as React from 'react';
 
 import { CARET_ICON_BOX_DIMENSION, CARET_ICON_SIZE, SCHEMA_ROW_OFFSET } from '../consts';
@@ -52,14 +53,14 @@ export const SchemaRow: React.FunctionComponent<SchemaRowProps> = ({ schemaNode,
   const childNodes = React.useMemo(() => calculateChildrenToShow(schemaNode), [schemaNode]);
 
   return (
-    <Box fontSize="sm" pos="relative" style={{ marginLeft: CARET_ICON_BOX_DIMENSION }}>
-      <Flex>
-        <Box flexGrow className="min-w-0">
-          <Box
+    <div className="sl-text-sm sl-relative" style={{ marginLeft: CARET_ICON_BOX_DIMENSION }}>
+      <div className="sl-flex">
+        <div className="sl-min-w-0 sl-flex-grow">
+          <div
             onClick={childNodes.length > 0 ? () => setExpanded(!isExpanded) : undefined}
-            cursor={childNodes.length > 0 ? 'pointer' : 'default'}
+            className={cn({'sl-cursor-pointer': childNodes.length > 0})}
           >
-            <Flex my={2}>
+            <div className="sl-flex sl-my-2">
               {childNodes.length > 0 ? (
                 <Caret
                   isExpanded={isExpanded}
@@ -84,23 +85,23 @@ export const SchemaRow: React.FunctionComponent<SchemaRowProps> = ({ schemaNode,
                   <Divider kind={schemaNode.subpath[0]} />
                 )}
 
-              <Flex flex={1} textOverflow="truncate" fontSize="base">
+              <div className="sl-flex sl-text-base sl-flex-1 sl-truncate">
                 <Property schemaNode={schemaNode} />
                 <Format schemaNode={schemaNode} />
-              </Flex>
+              </div>
               <Properties
                 required={isPropertyRequired(schemaNode)}
                 deprecated={isRegularNode(schemaNode) && schemaNode.deprecated}
                 validations={isRegularNode(schemaNode) ? schemaNode.validations : {}}
               />
-            </Flex>
+            </div>
 
             {typeof description === 'string' && description.length > 0 && (
-              <Flex flex={1} my={2} py="px" textOverflow="truncate">
+              <div className="sl-flex sl-flex-1 sl-my-2 sl-py-px sl-truncate">
                 <Description value={description} />
-              </Flex>
+              </div>
             )}
-          </Box>
+          </div>
 
           <Validations validations={isRegularNode(schemaNode) ? getValidationsFromSchema(schemaNode) : {}} />
 
@@ -108,16 +109,20 @@ export const SchemaRow: React.FunctionComponent<SchemaRowProps> = ({ schemaNode,
             // TODO (JJ): Add mosaic tooltip showing ref error
             <Icon title={refNode!.error!} color="danger" icon={faExclamationTriangle} size="sm" />
           )}
-        </Box>
-        <Box>{renderRowAddon ? renderRowAddon({ schemaNode, nestingLevel }) : null}</Box>
-      </Flex>
+        </div>
+        <div>{renderRowAddon ? renderRowAddon({ schemaNode, nestingLevel }) : null}</div>
+      </div>
       {childNodes.length > 0 && isExpanded ? (
-        <VStack divider>
-          {childNodes.map((childNode: SchemaNode) => (
-            <SchemaRow key={childNode.id} schemaNode={childNode} nestingLevel={nestingLevel + 1} />
+        <div className="sl-divide-y">
+          {childNodes.map((childNode: SchemaNode, index) => (
+            <React.Fragment key={childNode.id}>
+              {index > 0 && <div className="sl-border-t sl-self-stretch" />}
+              <SchemaRow schemaNode={childNode} nestingLevel={nestingLevel + 1} />
+            </React.Fragment>
+
           ))}
-        </VStack>
+        </div>
       ) : null}
-    </Box>
+    </div>
   );
 };

--- a/src/components/SchemaRow.tsx
+++ b/src/components/SchemaRow.tsx
@@ -16,8 +16,8 @@ import { useJSVOptionsContext } from '../contexts';
 import { isCombiner } from '../guards/isCombiner';
 import { calculateChildrenToShow, isFlattenableNode, isPropertyRequired } from '../tree';
 import { Caret, Description, Divider, Format, getValidationsFromSchema, Property, Validations } from './shared';
-import { Properties } from './shared/Properties';
 import { ChildStack } from './shared/ChildStack';
+import { Properties } from './shared/Properties';
 
 export interface SchemaRowProps {
   schemaNode: SchemaNode;
@@ -59,7 +59,7 @@ export const SchemaRow: React.FunctionComponent<SchemaRowProps> = ({ schemaNode,
         <div className="sl-min-w-0 sl-flex-grow">
           <div
             onClick={childNodes.length > 0 ? () => setExpanded(!isExpanded) : undefined}
-            className={cn({'sl-cursor-pointer': childNodes.length > 0})}
+            className={cn({ 'sl-cursor-pointer': childNodes.length > 0 })}
           >
             <div className="sl-flex sl-my-2">
               {childNodes.length > 0 ? (

--- a/src/components/SchemaRow.tsx
+++ b/src/components/SchemaRow.tsx
@@ -17,6 +17,7 @@ import { isCombiner } from '../guards/isCombiner';
 import { calculateChildrenToShow, isFlattenableNode, isPropertyRequired } from '../tree';
 import { Caret, Description, Divider, Format, getValidationsFromSchema, Property, Validations } from './shared';
 import { Properties } from './shared/Properties';
+import { ChildStack } from './shared/ChildStack';
 
 export interface SchemaRowProps {
   schemaNode: SchemaNode;
@@ -113,15 +114,7 @@ export const SchemaRow: React.FunctionComponent<SchemaRowProps> = ({ schemaNode,
         <div>{renderRowAddon ? renderRowAddon({ schemaNode, nestingLevel }) : null}</div>
       </div>
       {childNodes.length > 0 && isExpanded ? (
-        <div className="sl-divide-y">
-          {childNodes.map((childNode: SchemaNode, index) => (
-            <React.Fragment key={childNode.id}>
-              {index > 0 && <div className="sl-border-t sl-self-stretch" />}
-              <SchemaRow schemaNode={childNode} nestingLevel={nestingLevel + 1} />
-            </React.Fragment>
-
-          ))}
-        </div>
+        <ChildStack childNodes={childNodes} currentNestingLevel={nestingLevel} />
       ) : null}
     </div>
   );

--- a/src/components/shared/Caret.tsx
+++ b/src/components/shared/Caret.tsx
@@ -1,5 +1,5 @@
 import { faChevronDown, faChevronRight } from '@fortawesome/free-solid-svg-icons';
-import { Flex, Icon, IIconProps } from '@stoplight/mosaic';
+import { Icon, IIconProps } from '@stoplight/mosaic';
 import * as React from 'react';
 
 export interface ICaret {
@@ -9,7 +9,11 @@ export interface ICaret {
 }
 
 export const Caret: React.FunctionComponent<ICaret> = ({ style, size, isExpanded }) => (
-  <Flex pos="absolute" justify="center" p={1} cursor="pointer" role="button" style={style} color="muted">
+  <div
+    className="sl-flex sl-absolute sl-justify-center sl-p-1 sl-cursor-pointer sl-text-muted"
+    role="button"
+    style={style}
+  >
     <Icon size={size} icon={isExpanded ? faChevronDown : faChevronRight} />
-  </Flex>
+  </div>
 );

--- a/src/components/shared/Caret.tsx
+++ b/src/components/shared/Caret.tsx
@@ -11,8 +11,8 @@ export interface ICaret {
 export const Caret: React.FunctionComponent<ICaret> = ({ style, size, isExpanded }) => (
   <div
     className="sl-flex sl-absolute sl-justify-center sl-p-1 sl-cursor-pointer sl-text-muted"
-    role="button"
     style={style}
+    role="button"
   >
     <Icon size={size} icon={isExpanded ? faChevronDown : faChevronRight} />
   </div>

--- a/src/components/shared/ChildStack.tsx
+++ b/src/components/shared/ChildStack.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+import { SchemaNode } from '@stoplight/json-schema-tree';
+import { SchemaRow } from '../SchemaRow';
+
+type ChildStackProps = {
+  childNodes: readonly SchemaNode[];
+  currentNestingLevel: number;
+  className?: string;
+};
+export const ChildStack = ({ childNodes, currentNestingLevel, className }: ChildStackProps) => (
+  <div className={className}>
+    {childNodes.map((childNode: SchemaNode, index) => (
+      <React.Fragment key={childNode.id}>
+        {index > 0 && <div className="sl-border-t sl-self-stretch" />}
+        <SchemaRow schemaNode={childNode} nestingLevel={currentNestingLevel + 1} />
+      </React.Fragment>
+    ))}
+  </div>
+);

--- a/src/components/shared/ChildStack.tsx
+++ b/src/components/shared/ChildStack.tsx
@@ -1,5 +1,6 @@
-import * as React from 'react';
 import { SchemaNode } from '@stoplight/json-schema-tree';
+import * as React from 'react';
+
 import { SchemaRow } from '../SchemaRow';
 
 type ChildStackProps = {

--- a/src/components/shared/Description.tsx
+++ b/src/components/shared/Description.tsx
@@ -1,9 +1,8 @@
-import { Box } from '@stoplight/mosaic';
 import * as React from 'react';
 
 export const Description: React.FunctionComponent<{ value: string }> = ({ value }) => (
   // TODO (JJ): Add mosaic popover showing full description in MarkdownViewer
-  <Box title={value} textOverflow="truncate" w="full" color="muted">
+  <div className="sl-truncate sl-w-full sl-text-muted" title={value}>
     {value}
-  </Box>
+  </div>
 );

--- a/src/components/shared/Divider.tsx
+++ b/src/components/shared/Divider.tsx
@@ -7,7 +7,10 @@ export const Divider: React.FunctionComponent<{ kind?: SchemaCombinerName; style
   kind,
   style,
 }) => (
-  <div className="sl-flex sl-text-center sl-w-full sl-absolute" style={{ ...style, ...(kind && { top: -9 }), height: 1 }}>
+  <div
+    className="sl-flex sl-text-center sl-w-full sl-absolute"
+    style={{ ...style, ...(kind && { top: -9 }), height: 1 }}
+  >
     {kind && (
       <div className="sl-pr-2 sl--ml-6 sl-uppercase sl-text-sm sl-text-muted">{COMBINER_PRETTY_NAMES[kind]}</div>
     )}

--- a/src/components/shared/Divider.tsx
+++ b/src/components/shared/Divider.tsx
@@ -1,5 +1,4 @@
 import { SchemaCombinerName } from '@stoplight/json-schema-tree';
-import { Box, Flex } from '@stoplight/mosaic';
 import * as React from 'react';
 
 import { COMBINER_PRETTY_NAMES } from '../../consts';
@@ -8,12 +7,10 @@ export const Divider: React.FunctionComponent<{ kind?: SchemaCombinerName; style
   kind,
   style,
 }) => (
-  <Flex align="center" w="full" pos="absolute" style={{ ...style, ...(kind && { top: -9 }), height: 1 }}>
+  <div className="sl-flex sl-text-center sl-w-full sl-absolute" style={{ ...style, ...(kind && { top: -9 }), height: 1 }}>
     {kind && (
-      <Box pr={2} ml={-6} textTransform="uppercase" fontSize="sm" color="muted">
-        {COMBINER_PRETTY_NAMES[kind]}
-      </Box>
+      <div className="sl-pr-2 sl--ml-6 sl-uppercase sl-text-sm sl-text-muted">{COMBINER_PRETTY_NAMES[kind]}</div>
     )}
-    {!kind && <Box flex={1} style={{ height: 1, backgroundColor: 'lightgray' }} />}
-  </Flex>
+    {!kind && <div className="sl-flex-1" style={{ height: 1, backgroundColor: 'lightgray' }} />}
+  </div>
 );

--- a/src/components/shared/Format.tsx
+++ b/src/components/shared/Format.tsx
@@ -1,5 +1,4 @@
 import { isRegularNode, SchemaNode } from '@stoplight/json-schema-tree';
-import { Text } from '@stoplight/mosaic';
 import * as React from 'react';
 
 type FormatProps = {
@@ -11,5 +10,5 @@ export const Format: React.FunctionComponent<FormatProps> = ({ schemaNode }) => 
     return null;
   }
 
-  return <Text ml={2} color="muted">{`<${schemaNode.format}>`}</Text>;
+  return <span className="sl-ml-2 sl-text-muted">{`<${schemaNode.format}>`}</span>;
 };

--- a/src/components/shared/Properties.tsx
+++ b/src/components/shared/Properties.tsx
@@ -1,4 +1,3 @@
-import { Text } from '@stoplight/mosaic';
 import { Dictionary } from '@stoplight/types';
 import * as React from 'react';
 
@@ -21,28 +20,28 @@ export const Properties: React.FunctionComponent<IProperties> = ({
   const showVisibilityValidations = viewMode === 'standalone' && !!readOnly !== !!writeOnly;
   const visibility = showVisibilityValidations ? (
     readOnly ? (
-      <Text ml={2} color="muted">
+      <span className="sl-ml-2 sl-text-muted">
         read-only
-      </Text>
+      </span>
     ) : (
-      <Text ml={2} color="muted">
+      <span className="sl-ml-2 sl-text-muted">
         write-only
-      </Text>
+      </span>
     )
   ) : null;
 
   return (
     <>
       {deprecated ? (
-        <Text ml={2} color="warning">
+        <span className="sl-ml-2 sl-text-warning">
           deprecated
-        </Text>
+        </span>
       ) : null}
       {visibility}
       {required && (
-        <Text ml={2} color="warning">
+        <span className="sl-ml-2 sl-text-warning">
           required
-        </Text>
+        </span>
       )}
     </>
   );

--- a/src/components/shared/Properties.tsx
+++ b/src/components/shared/Properties.tsx
@@ -20,29 +20,17 @@ export const Properties: React.FunctionComponent<IProperties> = ({
   const showVisibilityValidations = viewMode === 'standalone' && !!readOnly !== !!writeOnly;
   const visibility = showVisibilityValidations ? (
     readOnly ? (
-      <span className="sl-ml-2 sl-text-muted">
-        read-only
-      </span>
+      <span className="sl-ml-2 sl-text-muted">read-only</span>
     ) : (
-      <span className="sl-ml-2 sl-text-muted">
-        write-only
-      </span>
+      <span className="sl-ml-2 sl-text-muted">write-only</span>
     )
   ) : null;
 
   return (
     <>
-      {deprecated ? (
-        <span className="sl-ml-2 sl-text-warning">
-          deprecated
-        </span>
-      ) : null}
+      {deprecated ? <span className="sl-ml-2 sl-text-warning">deprecated</span> : null}
       {visibility}
-      {required && (
-        <span className="sl-ml-2 sl-text-warning">
-          required
-        </span>
-      )}
+      {required && <span className="sl-ml-2 sl-text-warning">required</span>}
     </>
   );
 };

--- a/src/components/shared/Property.tsx
+++ b/src/components/shared/Property.tsx
@@ -1,5 +1,4 @@
 import { isReferenceNode, SchemaNode } from '@stoplight/json-schema-tree';
-import { Box, Link } from '@stoplight/mosaic';
 import * as React from 'react';
 
 import { useJSVOptionsContext } from '../../contexts';
@@ -25,18 +24,14 @@ export const Property: React.FunctionComponent<IProperty> = ({ schemaNode, schem
   return (
     <>
       {subpath.length > 0 && shouldShowPropertyName(schemaNode) && (
-        <Box mr={2} fontFamily="mono" fontWeight="bold">
-          {subpath[subpath.length - 1]}
-        </Box>
+        <div className="sl-mr-2 sl-font-mono sl-font-bold">{subpath[subpath.length - 1]}</div>
       )}
 
       <Types schemaNode={schemaNode} />
 
       {onGoToRef && isReferenceNode(schemaNode) && schemaNode.external && onGoToRef ? (
-        <Link
-          ml={2}
-          color="primary-light"
-          cursor="pointer"
+        <a
+          className="sl-ml-2 sl-cursor-pointer sl-text-primary-light"
           onClick={(e: React.MouseEvent) => {
             e.preventDefault();
             e.stopPropagation();
@@ -44,15 +39,13 @@ export const Property: React.FunctionComponent<IProperty> = ({ schemaNode, schem
           }}
         >
           (go to ref)
-        </Link>
+        </a>
       ) : null}
 
-      {childNodes.length > 0 && <Box ml={2} color="muted">{`{${childNodes.length}}`}</Box>}
+      {childNodes.length > 0 && <div className="sl-ml-2 sl-text-muted">{`{${childNodes.length}}`}</div>}
 
       {subpath.length > 1 && subpath[0] === 'patternProperties' ? (
-        <Box ml={2} textOverflow="truncate" color="muted">
-          (pattern property)
-        </Box>
+        <div className="sl-ml-2 sl-truncate sl-text-muted">(pattern property)</div>
       ) : null}
     </>
   );

--- a/src/components/shared/Types.tsx
+++ b/src/components/shared/Types.tsx
@@ -43,9 +43,7 @@ export const Types: React.FunctionComponent<{ schemaNode: SchemaNode }> = ({ sch
 
   const rendered = types.map((type, i, { length }) => (
     <React.Fragment key={type}>
-      <span className="sl-truncate sl-text-muted">
-        {shouldRenderName(type) ? printName(schemaNode) ?? type : type}
-      </span>
+      <span className="sl-truncate sl-text-muted">{shouldRenderName(type) ? printName(schemaNode) ?? type : type}</span>
       {i < length - 1 && (
         <span key={`${i}-sep`} className="sl-text-muted">
           {' or '}

--- a/src/components/shared/Types.tsx
+++ b/src/components/shared/Types.tsx
@@ -30,7 +30,7 @@ function getTypes(schemaNode: RegularNode): Array<SchemaNodeKind | SchemaCombine
 
 export const Types: React.FunctionComponent<{ schemaNode: SchemaNode }> = ({ schemaNode }) => {
   if (isReferenceNode(schemaNode)) {
-    return <span className="truncate">{schemaNode.value ?? '$ref'}</span>;
+    return <span className="sl-truncate">{schemaNode.value ?? '$ref'}</span>;
   }
 
   if (!isRegularNode(schemaNode)) {

--- a/src/components/shared/Types.tsx
+++ b/src/components/shared/Types.tsx
@@ -6,7 +6,6 @@ import {
   SchemaNode,
   SchemaNodeKind,
 } from '@stoplight/json-schema-tree';
-import { Box, Text } from '@stoplight/mosaic';
 import * as React from 'react';
 
 import { printName } from '../../utils';
@@ -31,7 +30,7 @@ function getTypes(schemaNode: RegularNode): Array<SchemaNodeKind | SchemaCombine
 
 export const Types: React.FunctionComponent<{ schemaNode: SchemaNode }> = ({ schemaNode }) => {
   if (isReferenceNode(schemaNode)) {
-    return <Text textOverflow="truncate">{schemaNode.value ?? '$ref'}</Text>;
+    return <span className="truncate">{schemaNode.value ?? '$ref'}</span>;
   }
 
   if (!isRegularNode(schemaNode)) {
@@ -44,17 +43,17 @@ export const Types: React.FunctionComponent<{ schemaNode: SchemaNode }> = ({ sch
 
   const rendered = types.map((type, i, { length }) => (
     <React.Fragment key={type}>
-      <Text textOverflow="truncate" color="muted">
+      <span className="sl-truncate sl-text-muted">
         {shouldRenderName(type) ? printName(schemaNode) ?? type : type}
-      </Text>
+      </span>
       {i < length - 1 && (
-        <Text key={`${i}-sep`} color="muted">
+        <span key={`${i}-sep`} className="sl-text-muted">
           {' or '}
-        </Text>
+        </span>
       )}
     </React.Fragment>
   ));
 
-  return rendered.length > 1 ? <Box textOverflow="truncate">{rendered}</Box> : <>{rendered}</>;
+  return rendered.length > 1 ? <div className="sl-truncate">{rendered}</div> : <>{rendered}</>;
 };
 Types.displayName = 'JsonSchemaViewer.Types';

--- a/src/components/shared/Validations.tsx
+++ b/src/components/shared/Validations.tsx
@@ -1,5 +1,4 @@
 import { RegularNode } from '@stoplight/json-schema-tree';
-import { Flex, Text } from '@stoplight/mosaic';
 import { Dictionary } from '@stoplight/types';
 import { capitalize, keys, omit, pick, pickBy, uniq } from 'lodash';
 import * as React from 'react';
@@ -88,38 +87,34 @@ export const Validations: React.FunctionComponent<IValidations> = ({ validations
 
 const NumberValidations = ({
   validations,
-  className,
 }: {
   validations: Partial<Record<typeof numberValidationNames[number], unknown>>;
-  className?: string;
 }) => {
   const entries = Object.entries(validations);
   if (!entries.length) {
     return null;
   }
   return (
-    <Flex my={2} color="muted">
+    <div className="sl-flex sl-my-2 sl-text-muted">
       {entries
         .map(([key, value]) => numberValidationFormatters[key](value))
         .map((value, i) => (
-          <Text key={i} mr={2} px={1} fontFamily="mono" border rounded="lg" className={className}>
+          <span key={i} className="sl-mr-2 sl-px-1 sl-font-mono sl-border sl-rounded-lg">
             {value}
-          </Text>
+          </span>
         ))}
-    </Flex>
+    </div>
   );
 };
 
-const KeyValueValidations = ({ validations, className }: { validations: Dictionary<unknown>; className?: string }) => (
+const KeyValueValidations = ({ validations }: { validations: Dictionary<unknown> }) => (
   <>
     {keys(validations)
       .filter(key => Object.keys(validationFormatters).includes(key))
       .map(key => {
         const validation = validationFormatters[key](validations[key]);
         if (validation) {
-          return (
-            <KeyValueValidation key={key} name={validation.name} values={validation.values} className={className} />
-          );
+          return <KeyValueValidation key={key} name={validation.name} values={validation.values} />;
         } else {
           return null;
         }
@@ -127,39 +122,31 @@ const KeyValueValidations = ({ validations, className }: { validations: Dictiona
   </>
 );
 
-const KeyValueValidation = ({ className, name, values }: { className?: string; name: string; values: string[] }) => {
+const KeyValueValidation = ({ name, values }: { name: string; values: string[] }) => {
   return (
-    <Flex flexWrap color="muted" my={2} className={className}>
-      <Text fontWeight="light">{capitalize(name)}:</Text>
+    <div className="sl-flex sl-flex-wrap sl-text-muted sl-my-2">
+      <span className="sl-text-light">{capitalize(name)}:</span>
       {uniq(values).map(value => (
-        <Text key={value} ml={2} px={1} fontFamily="mono" border rounded="lg" className={className}>
+        <span key={value} className="sl-ml-2 sl-px-1 sl-font-mono sl-border sl-rounded-lg">
           {value}
-        </Text>
+        </span>
       ))}
-    </Flex>
+    </div>
   );
 };
 
-const NameValidations = ({ validations, className }: { validations: Dictionary<unknown>; className?: string }) => (
+const NameValidations = ({ validations }: { validations: Dictionary<unknown> }) => (
   <>
     {keys(validations)
       .filter(key => validations[key])
       .map(key => {
         return (
-          <Flex key={key} flex={1} my={2}>
-            <Text
-              px={1}
-              color="muted"
-              fontFamily="mono"
-              border
-              rounded="lg"
-              fontSize="sm"
-              textTransform="capitalize"
-              className={className}
+          <div className="sl-flex sl-flex-1 sl-my-2" key={key}>
+            <span              className="sl-px-1 sl-text-muted sl-font-mono sl-border sl-rounded-lg sl-text-sm sl-capitalize"
             >
               {key}
-            </Text>
-          </Flex>
+            </span>
+          </div>
         );
       })}
   </>

--- a/src/components/shared/Validations.tsx
+++ b/src/components/shared/Validations.tsx
@@ -142,8 +142,7 @@ const NameValidations = ({ validations }: { validations: Dictionary<unknown> }) 
       .map(key => {
         return (
           <div className="sl-flex sl-flex-1 sl-my-2" key={key}>
-            <span              className="sl-px-1 sl-text-muted sl-font-mono sl-border sl-rounded-lg sl-text-sm sl-capitalize"
-            >
+            <span className="sl-px-1 sl-text-muted sl-font-mono sl-border sl-rounded-lg sl-text-sm sl-capitalize">
               {key}
             </span>
           </div>

--- a/src/components/shared/__tests__/Property.spec.tsx
+++ b/src/components/shared/__tests__/Property.spec.tsx
@@ -236,12 +236,12 @@ describe('Property component', () => {
 
       let wrapper = render(schema, ['properties', 'array-all-objects', 'items', 'properties', 'foo']);
       expect(wrapper).toHaveHTML(
-        '<div class="sl-font-mono sl-font-bold sl-mr-2">foo</div><span class="sl-truncate sl-text-muted">string</span>',
+        '<div class="sl-mr-2 sl-font-mono sl-font-bold">foo</div><span class="sl-truncate sl-text-muted">string</span>',
       );
 
       wrapper = render(schema, ['properties', 'array-all-objects', 'items', 'properties', 'bar']);
       expect(wrapper).toHaveHTML(
-        '<div class="sl-font-mono sl-font-bold sl-mr-2">bar</div><span class="sl-truncate sl-text-muted">string</span>',
+        '<div class="sl-mr-2 sl-font-mono sl-font-bold">bar</div><span class="sl-truncate sl-text-muted">string</span>',
       );
     });
 
@@ -260,7 +260,7 @@ describe('Property component', () => {
       const tree = buildTree(schema);
 
       const wrapper = mount(<Property schemaNode={findNodeWithPath(tree, ['properties', 'foo'])!} />);
-      expect(wrapper.find('div')).toHaveHTML('<div class="sl-font-mono sl-font-bold sl-mr-2">foo</div>');
+      expect(wrapper.find('div')).toHaveHTML('<div class="sl-mr-2 sl-font-mono sl-font-bold">foo</div>');
       wrapper.unmount();
     });
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1796,11 +1796,12 @@
     eslint-config-prettier "^6.14.0"
 
 "@stoplight/json-schema-merge-allof@^0.7.2":
-  version "0.7.2"
-  resolved "https://registry.yarnpkg.com/@stoplight/json-schema-merge-allof/-/json-schema-merge-allof-0.7.2.tgz#a9f4d95b4a95e943afa567c695a1d4a2add9b74a"
-  integrity sha512-fVS5GqYBlxZfX1fA9+ULiny8VaCR3O62p3BHYd7+30rf378pVW6UPPydeB5AXs5U621LJKYdrGyndpOdTJ5dFA==
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/@stoplight/json-schema-merge-allof/-/json-schema-merge-allof-0.7.3.tgz#65ae18f38593a8a4a1232c051f7c0a63fce129cc"
+  integrity sha512-+4Lz+fHn+t49OeYZetyBa0Qz4kPsNRMEYVLVHMuq9HWyu2E29Iv7bafPfb9d0cGHJK92SE7ha5xgsLCBEQCRKQ==
   dependencies:
     compute-lcm "^1.1.0"
+    fast-copy "^2.1.1"
     json-schema-compare "^0.2.2"
     lodash "^4.17.4"
 
@@ -6997,6 +6998,11 @@ fake-tag@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/fake-tag/-/fake-tag-1.0.1.tgz#1d59da482240a02bd83500ca98976530ed154b0d"
   integrity sha512-qmewZoBpa71mM+y6oxXYW/d1xOYQmeIvnEXAt1oCmdP0sqcogWYLepR87QL1jQVLSVMVYDq2cjY6ec/Wu8/4pg==
+
+fast-copy@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/fast-copy/-/fast-copy-2.1.1.tgz#f5cbcf2df64215e59b8e43f0b2caabc19848083a"
+  integrity sha512-Qod3DdRgFZ8GUIM6ygeoZYpQ0QLW9cf/FS9KhhjlYggcSZXWAemAw8BOCO5LuYCrR3Uj3qXDVTUzOUwG8C7beQ==
 
 fast-deep-equal@^2.0.1:
   version "2.0.1"


### PR DESCRIPTION
Times in parenthesis are mounting times of the 2x-stress schema story in Storybook.
- Bumps @stoplightio/json-schema-merge-allof (1660ms -> 1590ms)
- Removes trivial mosaic components from the performance-critical rendering paths: `SchemaRow` and beyond (1590ms -> 850ms)

The problem with mosaic components is that for almost 0 gain (beyond type-checking of style-props), you render yet another element, and especially yet another `forwardRef`-ed element, both of which eat up performance as you scale. 