### PR TITLE
fix: readOnly/writeOnly not respected for >=2 levels

### DIFF
--- a/src/components/JsonSchemaViewer.tsx
+++ b/src/components/JsonSchemaViewer.tsx
@@ -33,8 +33,22 @@ export interface IJsonSchemaViewer {
 export const ViewModeContext = React.createContext<ViewMode>('standalone');
 ViewModeContext.displayName = 'ViewModeContext';
 
+export const SchemaTreeStoreContext = React.createContext<TreeStore<SchemaTree>>(
+  new TreeStore(
+    new SchemaTree({}, new TreeState(), {
+      mergeAllOf: true,
+      expandedDepth: -1,
+      resolveRef: void 0,
+      shouldResolveEagerly: false,
+      onPopulate: void 0,
+    }),
+    new TreeState(),
+  ),
+);
+SchemaTreeStoreContext.displayName = 'SchemaTreeStoreContext';
+
 export class JsonSchemaViewerComponent extends React.PureComponent<IJsonSchemaViewer & ErrorBoundaryForwardedProps> {
-  protected readonly treeStore: TreeStore;
+  protected readonly treeStore: TreeStore<SchemaTree>;
   protected readonly tree: SchemaTree;
   protected readonly treeState: TreeState;
 
@@ -124,7 +138,15 @@ export class JsonSchemaViewerComponent extends React.PureComponent<IJsonSchemaVi
     return (
       <div className={cn(className, 'JsonSchemaViewer flex flex-col relative')}>
         <ViewModeContext.Provider value={this.props.viewMode ?? 'standalone'}>
-          <SchemaTreeComponent expanded={expanded} name={name} schema={schema} treeStore={this.treeStore} {...props} />
+          <SchemaTreeStoreContext.Provider value={this.treeStore}>
+            <SchemaTreeComponent
+              expanded={expanded}
+              name={name}
+              schema={schema}
+              treeStore={this.treeStore}
+              {...props}
+            />
+          </SchemaTreeStoreContext.Provider>
         </ViewModeContext.Provider>
       </div>
     );


### PR DESCRIPTION
Addresses https://github.com/stoplightio/platform-internal/issues/5476
This is already fixed in beta, which uses entirely different code, but Studio cannot use v4 just yet, thus a dedicated change had to be applied.

FWIW, I'm glad we moved all the complexity away from JSV :sweat_smile: 
v3 is quite tangled at this point.