### PR TITLE
fix: use items validation for flattened arrays

### DIFF
--- a/src/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/src/__tests__/__snapshots__/index.spec.tsx.snap
@@ -2658,7 +2658,11 @@ exports[`HTML Output should match tickets.schema.json 1`] = `
           <div>availableDeliveryTypes</div>
           <span class=\\"text-green-6 dark:text-green-4\\">array[string]</span>
         </div>
-        <div></div>
+        <span class=\\"bp3-popover-wrapper\\">
+          <span class=\\"bp3-popover-target\\">
+            <div><span class=\\"text-darken-7 dark:text-lighten-6\\">+1</span></div>
+          </span>
+        </span>
       </div>
     </div>
   </div>
@@ -2669,7 +2673,11 @@ exports[`HTML Output should match tickets.schema.json 1`] = `
           <div>ticketRecipients</div>
           <span class=\\"text-green-6 dark:text-green-4\\">array[string]</span>
         </div>
-        <div></div>
+        <span class=\\"bp3-popover-wrapper\\">
+          <span class=\\"bp3-popover-target\\">
+            <div><span class=\\"text-darken-7 dark:text-lighten-6\\">+1</span></div>
+          </span>
+        </span>
       </div>
     </div>
   </div>

--- a/src/tree/utils/walk.ts
+++ b/src/tree/utils/walk.ts
@@ -49,10 +49,24 @@ export function* processNode(node: JSONSchema4): IterableIterator<SchemaNode> {
       yield combinerNode;
     }
   } else if (type) {
+    const primaryType = getPrimaryType(node);
+    let validationNOde: JSONSchema4 = node;
+    if (
+      primaryType === SchemaKind.Array &&
+      _isObject(node.items) &&
+      !Array.isArray(node.items) &&
+      getCombiners(node.items) === void 0
+    ) {
+      const validationNodePrimaryType = getPrimaryType(node.items);
+      if (validationNodePrimaryType !== SchemaKind.Array && validationNodePrimaryType !== SchemaKind.Object) {
+        validationNOde = node.items;
+      }
+    }
+
     const base: IBaseNode = {
       id: generateId(),
       type: flattenTypes(type),
-      validations: getValidations(node),
+      validations: getValidations(validationNOde),
       annotations: getAnnotations(node),
       ...('required' in node && { required: normalizeRequired(node.required) }),
       enum: node.enum,

--- a/src/tree/utils/walk.ts
+++ b/src/tree/utils/walk.ts
@@ -50,7 +50,7 @@ export function* processNode(node: JSONSchema4): IterableIterator<SchemaNode> {
     }
   } else if (type) {
     const primaryType = getPrimaryType(node);
-    let validationNOde: JSONSchema4 = node;
+    let validationNode: JSONSchema4 = node;
     if (
       primaryType === SchemaKind.Array &&
       _isObject(node.items) &&
@@ -59,14 +59,14 @@ export function* processNode(node: JSONSchema4): IterableIterator<SchemaNode> {
     ) {
       const validationNodePrimaryType = getPrimaryType(node.items);
       if (validationNodePrimaryType !== SchemaKind.Array && validationNodePrimaryType !== SchemaKind.Object) {
-        validationNOde = node.items;
+        validationNode = node.items;
       }
     }
 
     const base: IBaseNode = {
       id: generateId(),
       type: flattenTypes(type),
-      validations: getValidations(validationNOde),
+      validations: getValidations(validationNode),
       annotations: getAnnotations(node),
       ...('required' in node && { required: normalizeRequired(node.required) }),
       enum: node.enum,


### PR DESCRIPTION
Addresses https://github.com/stoplightio/platform-internal/issues/5799

![image](https://user-images.githubusercontent.com/9273484/113946153-08384d80-9808-11eb-825a-fbf186cf8b6a.png)
I'm so happy this code is entirely gone in beta, and that JST has it done more reasonably :see_no_evil: 

`tickets.schema.json` has been updated due to that fix, see the portion of that whole schema document
```json
    "ticketRecipients": {
                            "type": "array",
                            "items": {
                              "type": "string",
                              "enum": [
                                "BOOKER",
                                "CUSTOMER",
                                "PASSENGER",
                                "THIRD_PARTY"
                              ]
                            }
                          },
```