### PR TITLE
feat: do not display min/max values for oas formats

### DIFF
--- a/src/components/__tests__/Validations.spec.tsx
+++ b/src/components/__tests__/Validations.spec.tsx
@@ -32,6 +32,8 @@ describe('Validations component', () => {
       expect(wrapper).toHaveText('deprecated');
     });
   });
+
+  test.todo('when oas format is specified');
 });
 
 describe('Format', () => {

--- a/src/components/__tests__/Validations.spec.tsx
+++ b/src/components/__tests__/Validations.spec.tsx
@@ -32,8 +32,6 @@ describe('Validations component', () => {
       expect(wrapper).toHaveText('deprecated');
     });
   });
-
-  test.todo('when oas format is specified');
 });
 
 describe('Format', () => {

--- a/src/utils/__tests__/getValidations.spec.ts
+++ b/src/utils/__tests__/getValidations.spec.ts
@@ -18,6 +18,40 @@ describe('getValidations util', () => {
     });
   });
 
+  describe('when oas format is specified', () => {
+    test('given default range, should not ignore both minimum and maximum values', () => {
+      expect(
+        getValidations({
+          type: 'integer',
+          format: 'int64',
+          minimum: 0 - Math.pow(2, 63),
+          maximum: Math.pow(2, 63) - 1,
+        }),
+      ).toStrictEqual({ format: 'int64' });
+    });
+
+    test('given customized range, should include changed values', () => {
+      expect(
+        getValidations({ type: 'integer', format: 'int32', minimum: 20, maximum: Math.pow(2, 31) - 1 }),
+      ).toStrictEqual({
+        format: 'int32',
+        minimum: 20,
+      });
+
+      expect(
+        getValidations({
+          type: 'number',
+          format: 'float',
+          minimum: 0 - Math.pow(2, 128),
+          maximum: Math.pow(2, 16) - 1,
+        }),
+      ).toStrictEqual({
+        format: 'float',
+        maximum: Math.pow(2, 16) - 1,
+      });
+    });
+  });
+
   test('should support integer type', () => {
     expect(
       getValidations({

--- a/src/utils/getValidations.ts
+++ b/src/utils/getValidations.ts
@@ -47,7 +47,7 @@ const OAS_FORMATS = {
   },
 };
 
-function filterOutMaxAndMin(values: Dictionary<unknown>) {
+function filterOutFormatValidations(values: Dictionary<unknown>) {
   const { format } = values;
 
   if (typeof format !== 'string' || !(format in OAS_FORMATS)) return values;
@@ -86,7 +86,7 @@ function getTypeValidations(type: JSONSchema4TypeName | JSONSchema4TypeName[]): 
 export const getValidations = (node: JSONSchema4): Dictionary<unknown> => {
   const extraValidations = node.type && getTypeValidations(node.type);
   const deprecated = getDeprecatedValue(node);
-  return filterOutMaxAndMin({
+  return filterOutFormatValidations({
     ..._pick(node, COMMON_VALIDATION_TYPES),
     ...(extraValidations && _pick(node, extraValidations)),
     ...(deprecated !== void 0 && { deprecated }),

--- a/src/utils/getValidations.ts
+++ b/src/utils/getValidations.ts
@@ -25,6 +25,44 @@ const VALIDATION_TYPES = {
   array: ['additionalItems', 'minItems', 'maxItems', 'uniqueItems'],
 };
 
+const OAS_FORMATS = {
+  int32: {
+    minimum: 0 - Math.pow(2, 31),
+    maximum: Math.pow(2, 31) - 1,
+  },
+  int64: {
+    minimum: 0 - Math.pow(2, 63),
+    maximum: Math.pow(2, 63) - 1,
+  },
+  float: {
+    minimum: 0 - Math.pow(2, 128),
+    maximum: Math.pow(2, 128) - 1,
+  },
+  double: {
+    minimum: 0 - Number.MAX_VALUE,
+    maximum: Number.MAX_VALUE,
+  },
+  byte: {
+    pattern: '^[\\w\\d+\\/=]*$',
+  },
+};
+
+function filterOutMaxAndMin(values: Dictionary<unknown>) {
+  const { format } = values;
+
+  if (typeof format !== 'string' || !(format in OAS_FORMATS)) return values;
+
+  const newValues = { ...values };
+
+  for (const [key, value] of Object.entries(OAS_FORMATS[format])) {
+    if (value === newValues[key]) {
+      delete newValues[key];
+    }
+  }
+
+  return newValues;
+}
+
 function getDeprecatedValue(node: JSONSchema4): Optional<boolean> {
   if ('x-deprecated' in node) {
     return !!node['x-deprecated'];
@@ -48,9 +86,9 @@ function getTypeValidations(type: JSONSchema4TypeName | JSONSchema4TypeName[]): 
 export const getValidations = (node: JSONSchema4): Dictionary<unknown> => {
   const extraValidations = node.type && getTypeValidations(node.type);
   const deprecated = getDeprecatedValue(node);
-  return {
+  return filterOutMaxAndMin({
     ..._pick(node, COMMON_VALIDATION_TYPES),
     ...(extraValidations && _pick(node, extraValidations)),
     ...(deprecated !== void 0 && { deprecated }),
-  };
+  });
 };


### PR DESCRIPTION
Addresses https://github.com/stoplightio/platform-internal/issues/4350

Initially I wanted to address this directly in `http-spec`, but I quickly changed my mind, as this could potentially break certain usages. These 5 formats are OAS-specific, and JSON Schema does not support them, therefore the conversion we do includes correct ranges, so that generic JSON Schema tooling can interpret such a schema correctly.
Unfortunately, as a side effect, the values get inserted to the document, and JSV renders them.
The solution I decided to go with is rather simple. Since a format implies the valid ranges, we do not need to show it unless a given value was overridden manually.

To be ported to JST / JSV v4.