### PR TITLE
chore: bump json-schema-tree to 2.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "@fortawesome/free-solid-svg-icons": "^5.15.2",
     "@stoplight/json": "^3.10.0",
-    "@stoplight/json-schema-tree": "^2.0.0",
+    "@stoplight/json-schema-tree": "^2.0.1",
     "@stoplight/mosaic": "1.0.0-beta.46",
     "@stoplight/react-error-boundary": "^1.0.0",
     "@types/json-schema": "^7.0.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2365,10 +2365,10 @@
     json-schema-compare "^0.2.2"
     lodash "^4.17.4"
 
-"@stoplight/json-schema-tree@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@stoplight/json-schema-tree/-/json-schema-tree-2.0.0.tgz#00d54cb6aa2a791c34be91fc30cc92e6d448258c"
-  integrity sha512-vnzcb0TC07xh89lAVGjBTJ2CWvCqmDJDIs3u+gvgvjDPY86CQ0Wl4D2Cmb0iuqd986aiDPc8vDQf1N0dSq5+9A==
+"@stoplight/json-schema-tree@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@stoplight/json-schema-tree/-/json-schema-tree-2.0.1.tgz#0affbc2c71b7cffab275385b367332fe0eaaf04e"
+  integrity sha512-K+NP7dNbcwoA3OUuGsG0uZ6PJjVSP9kq0QN5+j9uHCshbLfUHwtgx9JXCX64HFWyew6HhF9wUTnzFGw/vvo+5g==
   dependencies:
     "@stoplight/json" "^3.12.0"
     "@stoplight/json-schema-merge-allof" "^0.7.5"


### PR DESCRIPTION
Relates to https://github.com/stoplightio/elements/issues/1163