### PR TITLE
feat: do not wrap string validations

### DIFF
--- a/src/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/src/__tests__/__snapshots__/index.spec.tsx.snap
@@ -349,8 +349,8 @@ exports[`HTML Output given anyOf combiner placed next to allOf given allOf mergi
                   </div>
                   <div>
                     <span>Allowed values:</span>
-                    <span>\\"admin\\"</span>
-                    <span>\\"editor\\"</span>
+                    <span>admin</span>
+                    <span>editor</span>
                   </div>
                 </div>
                 <div></div>
@@ -562,8 +562,8 @@ exports[`HTML Output given oneOf combiner placed next to allOf given allOf mergi
                   </div>
                   <div>
                     <span>Allowed values:</span>
-                    <span>\\"admin\\"</span>
-                    <span>\\"editor\\"</span>
+                    <span>admin</span>
+                    <span>editor</span>
                   </div>
                 </div>
                 <div></div>
@@ -1006,12 +1006,12 @@ exports[`HTML Output should match arrays/of-complex-objects.json 1`] = `
                   </div>
                   <div>
                     <span>Allowed value:</span>
-                    <span>\\"Constant name\\"</span>
+                    <span>Constant name</span>
                   </div>
                   <div>
                     <span>Example values:</span>
-                    <span>\\"Example name\\"</span>
-                    <span>\\"Different name\\"</span>
+                    <span>Example name</span>
+                    <span>Different name</span>
                   </div>
                 </div>
                 <div></div>
@@ -1126,12 +1126,12 @@ exports[`HTML Output should match arrays/of-complex-objects.json 1`] = `
                   <div><span>&gt;= 2 characters</span></div>
                   <div>
                     <span>Default value:</span>
-                    <span>\\"default@email.com\\"</span>
+                    <span>default@email.com</span>
                   </div>
                   <div>
                     <span>Example values:</span>
-                    <span>\\"one@email.com\\"</span>
-                    <span>\\"two@email.com\\"</span>
+                    <span>one@email.com</span>
+                    <span>two@email.com</span>
                   </div>
                 </div>
                 <div></div>
@@ -2461,9 +2461,9 @@ exports[`HTML Output should match combiners/allOfs/with-type.json 1`] = `
                   </div>
                   <div>
                     <span>Allowed values:</span>
-                    <span>\\"Cancel\\"</span>
-                    <span>\\"Confirm\\"</span>
-                    <span>\\"Update\\"</span>
+                    <span>Cancel</span>
+                    <span>Confirm</span>
+                    <span>Update</span>
                   </div>
                 </div>
                 <div></div>
@@ -2589,7 +2589,7 @@ exports[`HTML Output should match combiners/oneof-with-array-type.json 1`] = `
                   </div>
                   <div>
                     <span>Allowed value:</span>
-                    <span>\\"test\\"</span>
+                    <span>test</span>
                   </div>
                 </div>
                 <div></div>
@@ -2644,7 +2644,7 @@ exports[`HTML Output should match combiners/oneof-within-array-item.json 1`] = `
                   </div>
                   <div>
                     <span>Allowed value:</span>
-                    <span>\\"test\\"</span>
+                    <span>test</span>
                   </div>
                 </div>
                 <div></div>
@@ -2687,12 +2687,12 @@ exports[`HTML Output should match default-schema.json 1`] = `
                 </div>
                 <div>
                   <span>Allowed value:</span>
-                  <span>\\"Constant name\\"</span>
+                  <span>Constant name</span>
                 </div>
                 <div>
                   <span>Example values:</span>
-                  <span>\\"Example name\\"</span>
-                  <span>\\"Different name\\"</span>
+                  <span>Example name</span>
+                  <span>Different name</span>
                 </div>
               </div>
               <div></div>
@@ -2807,12 +2807,12 @@ exports[`HTML Output should match default-schema.json 1`] = `
                 <div><span>&gt;= 2 characters</span></div>
                 <div>
                   <span>Default value:</span>
-                  <span>\\"default@email.com\\"</span>
+                  <span>default@email.com</span>
                 </div>
                 <div>
                   <span>Example values:</span>
-                  <span>\\"one@email.com\\"</span>
-                  <span>\\"two@email.com\\"</span>
+                  <span>one@email.com</span>
+                  <span>two@email.com</span>
                 </div>
               </div>
               <div></div>
@@ -3439,12 +3439,12 @@ exports[`HTML Output should match tickets.schema.json 1`] = `
                     </div>
                     <div>
                       <span>Allowed values:</span>
-                      <span>\\"COMPLETED\\"</span>
-                      <span>\\"ACTIVE\\"</span>
+                      <span>COMPLETED</span>
+                      <span>ACTIVE</span>
                     </div>
                     <div>
                       <span>Default value:</span>
-                      <span>\\"ACTIVE\\"</span>
+                      <span>ACTIVE</span>
                     </div>
                   </div>
                   <div></div>
@@ -3529,10 +3529,10 @@ exports[`HTML Output should match tickets.schema.json 1`] = `
                             </div>
                             <div>
                               <span>Allowed values:</span>
-                              <span>\\"HOMEPRINT\\"</span>
-                              <span>\\"TICKETLESS\\"</span>
-                              <span>\\"PRINT_AT_KIOSK\\"</span>
-                              <span>\\"SECURE_PAPER\\"</span>
+                              <span>HOMEPRINT</span>
+                              <span>TICKETLESS</span>
+                              <span>PRINT_AT_KIOSK</span>
+                              <span>SECURE_PAPER</span>
                             </div>
                           </div>
                           <div></div>

--- a/src/components/shared/Validations.tsx
+++ b/src/components/shared/Validations.tsx
@@ -63,11 +63,11 @@ const createValidationsFormatter = (name: string, options?: { exact?: boolean; n
 };
 
 const validationFormatters: Record<string, (value: unknown) => ValidationFormat | null> = {
-  enum: createValidationsFormatter('Allowed'),
-  examples: createValidationsFormatter('Example'),
+  enum: createValidationsFormatter('Allowed', { nowrap: true }),
+  examples: createValidationsFormatter('Example', { nowrap: true }),
   multipleOf: createValidationsFormatter('Multiple of', { exact: true }),
   pattern: createValidationsFormatter('Match pattern', { exact: true, nowrap: true }),
-  default: createValidationsFormatter('Default'),
+  default: createValidationsFormatter('Default', { nowrap: true }),
 };
 
 const oasFormats = {

--- a/src/components/shared/__tests__/Validations.spec.tsx
+++ b/src/components/shared/__tests__/Validations.spec.tsx
@@ -43,9 +43,9 @@ describe('Validations component', () => {
     const wrapper = mount(<Validations validations={validations} />);
 
     expect(wrapper).toIncludeText('>= 2 characters<= 4 characters');
-    expect(wrapper).toIncludeText('Default value:"foo"');
-    expect(wrapper).toIncludeText('Example values:"Example 1""Example 2"');
-    expect(wrapper).toIncludeText('Allowed value:"bar"');
+    expect(wrapper).toIncludeText('Default value:foo');
+    expect(wrapper).toIncludeText('Example values:Example 1Example 2');
+    expect(wrapper).toIncludeText('Allowed value:bar');
   });
 
   it('should not render hidden example validations', () => {


### PR DESCRIPTION
Addresses: https://github.com/stoplightio/platform-internal/issues/7377

Quotes were added to distinguish the type of validation. 
This PR makes `enum`, `examples` and `default` not show quotes regardless of type.