### PR TITLE
fix: check for array child enum

### DIFF
--- a/src/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/src/__tests__/__snapshots__/index.spec.tsx.snap
@@ -3617,6 +3617,13 @@ exports[`HTML Output should match tickets.schema.json 1`] = `
                                     </div>
                                   </div>
                                 </div>
+                                <div>
+                                  <span>Allowed values:</span>
+                                  <span>\\"POSTAL\\"</span>
+                                  <span>\\"PICK_UP_STATION\\"</span>
+                                  <span>\\"E-MAIL\\"</span>
+                                  <span>\\"LOYALTY_CARD\\"</span>
+                                </div>
                               </div>
                               <div></div>
                             </div>
@@ -3632,6 +3639,13 @@ exports[`HTML Output should match tickets.schema.json 1`] = `
                                       <span>array of strings</span>
                                     </div>
                                   </div>
+                                </div>
+                                <div>
+                                  <span>Allowed values:</span>
+                                  <span>\\"BOOKER\\"</span>
+                                  <span>\\"CUSTOMER\\"</span>
+                                  <span>\\"PASSENGER\\"</span>
+                                  <span>\\"THIRD_PARTY\\"</span>
                                 </div>
                               </div>
                               <div></div>

--- a/src/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/src/__tests__/__snapshots__/index.spec.tsx.snap
@@ -3619,10 +3619,10 @@ exports[`HTML Output should match tickets.schema.json 1`] = `
                                 </div>
                                 <div>
                                   <span>Allowed values:</span>
-                                  <span>\\"POSTAL\\"</span>
-                                  <span>\\"PICK_UP_STATION\\"</span>
-                                  <span>\\"E-MAIL\\"</span>
-                                  <span>\\"LOYALTY_CARD\\"</span>
+                                  <span>POSTAL</span>
+                                  <span>PICK_UP_STATION</span>
+                                  <span>E-MAIL</span>
+                                  <span>LOYALTY_CARD</span>
                                 </div>
                               </div>
                               <div></div>
@@ -3642,10 +3642,10 @@ exports[`HTML Output should match tickets.schema.json 1`] = `
                                 </div>
                                 <div>
                                   <span>Allowed values:</span>
-                                  <span>\\"BOOKER\\"</span>
-                                  <span>\\"CUSTOMER\\"</span>
-                                  <span>\\"PASSENGER\\"</span>
-                                  <span>\\"THIRD_PARTY\\"</span>
+                                  <span>BOOKER</span>
+                                  <span>CUSTOMER</span>
+                                  <span>PASSENGER</span>
+                                  <span>THIRD_PARTY</span>
                                 </div>
                               </div>
                               <div></div>

--- a/src/components/shared/Validations.tsx
+++ b/src/components/shared/Validations.tsx
@@ -1,4 +1,4 @@
-import { RegularNode } from '@stoplight/json-schema-tree';
+import { isRegularNode, RegularNode } from '@stoplight/json-schema-tree';
 import { Flex, Text } from '@stoplight/mosaic';
 import { Dictionary } from '@stoplight/types';
 import capitalize from 'lodash/capitalize.js';
@@ -202,7 +202,15 @@ export function validationCount(schemaNode: RegularNode) {
 
 export function getValidationsFromSchema(schemaNode: RegularNode) {
   return {
-    ...(schemaNode.enum !== null ? { enum: schemaNode.enum } : null),
+    ...(schemaNode.enum !== null
+      ? { enum: schemaNode.enum }
+      : // in case schemaNode is type: "array", check if its child have defined enum
+      schemaNode.primaryType === 'array' &&
+        schemaNode.children?.length === 1 &&
+        isRegularNode(schemaNode.children[0]) &&
+        schemaNode.children[0].enum !== null
+      ? { enum: schemaNode.children[0].enum }
+      : null),
     ...('annotations' in schemaNode
       ? {
           ...(schemaNode.annotations.default ? { default: schemaNode.annotations.default } : null),

--- a/src/components/shared/__tests__/Validations.spec.tsx
+++ b/src/components/shared/__tests__/Validations.spec.tsx
@@ -63,7 +63,7 @@ describe('Validations component', () => {
     const validations = getValidationsFromSchema(node);
     const wrapper = mount(<Validations validations={validations} />);
 
-    expect(wrapper).toIncludeText('Allowed values:"p1""p2""p3"');
+    expect(wrapper).toIncludeText('Allowed values:p1p2p3');
   });
 
   it('should not render hidden example validations', () => {

--- a/src/components/shared/__tests__/Validations.spec.tsx
+++ b/src/components/shared/__tests__/Validations.spec.tsx
@@ -1,11 +1,12 @@
 import 'jest-enzyme';
 
-import { RegularNode } from '@stoplight/json-schema-tree';
+import { isRegularNode, RegularNode } from '@stoplight/json-schema-tree';
 import { mount } from 'enzyme';
 import * as React from 'react';
 
 import { Validations } from '../../shared';
 import { getValidationsFromSchema } from '../Validations';
+import { buildTree } from './utils';
 
 describe('Validations component', () => {
   it('should render number type validations', () => {
@@ -46,6 +47,23 @@ describe('Validations component', () => {
     expect(wrapper).toIncludeText('Default value:"foo"');
     expect(wrapper).toIncludeText('Example values:"Example 1""Example 2"');
     expect(wrapper).toIncludeText('Allowed value:"bar"');
+  });
+
+  it('should check for array child enum', () => {
+    const tree = buildTree({
+      type: 'array',
+      items: {
+        enum: ['p1', 'p2', 'p3'],
+      },
+    });
+
+    const node = tree.children[0] as RegularNode;
+
+    expect(isRegularNode(node)).toBe(true);
+    const validations = getValidationsFromSchema(node);
+    const wrapper = mount(<Validations validations={validations} />);
+
+    expect(wrapper).toIncludeText('Allowed values:"p1""p2""p3"');
   });
 
   it('should not render hidden example validations', () => {


### PR DESCRIPTION
For stoplightio/elements#1665

I believe the issue occurs because type: array node is not recursively processed like object type so enum property was never found. This fixes the issue described in the ticket but it also changed the jest snapshot for a schema defined in `src/__fixtures__/tickets.schema.json` and indeed, found enums that should be included for a property like this:

```json
"availableDeliveryTypes": {
  "type": "array",
  "items": {
    "type": "string",
    "enum": [
      "POSTAL",
      "PICK_UP_STATION",
      "E-MAIL",
      "LOYALTY_CARD"
    ]
  }
}
```