### PR TITLE
fix: removed NameValidations to properly show default values

### DIFF
--- a/src/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/src/__tests__/__snapshots__/index.spec.tsx.snap
@@ -3583,7 +3583,10 @@ exports[`HTML Output should match tickets.schema.json 1`] = `
                                 </div>
                               </div>
                             </div>
-                            <div><span>examples</span></div>
+                            <div>
+                              <span>Example value:</span>
+                              <span>true</span>
+                            </div>
                           </div>
                           <div></div>
                         </div>

--- a/src/components/shared/Validations.tsx
+++ b/src/components/shared/Validations.tsx
@@ -5,7 +5,6 @@ import capitalize from 'lodash/capitalize.js';
 import keys from 'lodash/keys.js';
 import omit from 'lodash/omit.js';
 import pick from 'lodash/pick.js';
-import pickBy from 'lodash/pickBy.js';
 import uniq from 'lodash/uniq.js';
 import * as React from 'react';
 
@@ -108,13 +107,8 @@ function filterOutOasFormatValidations(format: string, values: Dictionary<unknow
 
 export const Validations: React.FunctionComponent<IValidations> = ({ validations, hideExamples }) => {
   const numberValidations = pick(validations, numberValidationNames);
-  const booleanValidations = omit(
-    pickBy(validations, v => ['true', 'false'].includes(String(v))),
-    excludedValidations,
-  );
   const keyValueValidations = omit(validations, [
     ...keys(numberValidations),
-    ...keys(booleanValidations),
     ...excludedValidations,
     ...(hideExamples ? exampleValidationNames : []),
   ]);
@@ -123,7 +117,6 @@ export const Validations: React.FunctionComponent<IValidations> = ({ validations
     <>
       <NumberValidations validations={numberValidations} />
       <KeyValueValidations validations={keyValueValidations} />
-      <NameValidations validations={booleanValidations} />
     </>
   );
 };
@@ -176,20 +169,6 @@ const KeyValueValidation = ({ name, values }: { name: string; values: string[] }
   );
 };
 
-const NameValidations = ({ validations }: { validations: Dictionary<unknown> }) => (
-  <>
-    {keys(validations).length ? (
-      <Flex flexWrap maxW="full">
-        {keys(validations)
-          .filter(key => validations[key])
-          .map(key => (
-            <Value key={key} name={key} className="sl-text-muted sl-capitalize" />
-          ))}
-      </Flex>
-    ) : null}
-  </>
-);
-
 const Value = ({ name, className }: { name: string; className?: string }) => (
   <Text
     px={1}
@@ -226,7 +205,7 @@ export function getValidationsFromSchema(schemaNode: RegularNode) {
       : null),
     ...('annotations' in schemaNode
       ? {
-          ...(schemaNode.annotations.default ? { default: schemaNode.annotations.default } : null),
+          ...(schemaNode.annotations.default !== void 0 ? { default: schemaNode.annotations.default } : null),
           ...(schemaNode.annotations.examples ? { examples: schemaNode.annotations.examples } : null),
         }
       : null),


### PR DESCRIPTION
For stoplightio/platform-internal#9043

I couldn't find the reason why `NameValidations` were used for boolean types so I removed it 🤷‍♂️ 

Now, in case of

```json
"defaultExample1": {
  "type": "boolean",
  "default": true
},
"defaultExample2": {
  "type": "boolean",
  "default": false
}
```

It shows:

<img width="229" alt="Screenshot 2021-11-29 at 15 02 44" src="https://user-images.githubusercontent.com/1868852/143881702-39174cc6-b54b-457c-8787-3e7221836a7a.png">

Rather than displaying `Default` in case `default: true` and nothing in case of `default: false`.

Besides that, I noticed it also fixed the issue with some other boolean types like:

```json
"something": {
  "type": "boolean",
  "example": true
}
```

<img width="163" alt="Screenshot 2021-11-29 at 15 04 25" src="https://user-images.githubusercontent.com/1868852/143881933-e84b8a85-23ff-4397-816b-93157026221f.png">

Which is was previously displayed as:

<img width="230" alt="Screenshot 2021-11-29 at 15 06 02" src="https://user-images.githubusercontent.com/1868852/143882166-4529109e-c30b-474c-95d5-e7775446f476.png">

@mallachari Do you remember why was `NameValidations` needed for booleans? Is there some cases that i'm not seeing which this PR could broke?