### PR TITLE
fix: path crumbs compat with virtual scroll containers

### DIFF
--- a/src/__stories__/JsonSchemaViewer.tsx
+++ b/src/__stories__/JsonSchemaViewer.tsx
@@ -140,7 +140,8 @@ storiesOf('JsonSchemaViewer', module)
         </Box>
       </InvertTheme>
     );
-  });
+  })
+  .add('maxHeight', () => <JsonSchemaViewer schema={schema as JSONSchema4} maxHeight={number('maxHeight', 500)} />);
 
 storiesOf('JsonSchemaViewer/combiners', module)
   .addDecorator(withKnobs)

--- a/src/__stories__/_styles.scss
+++ b/src/__stories__/_styles.scss
@@ -2,8 +2,7 @@
 @import '~@stoplight/mosaic/themes/default.css';
 
 .JsonSchemaViewer {
-  margin: auto;
+  margin: 20px auto;
   width: 100%;
-  padding: 20px;
   max-width: 800px;
 }

--- a/src/hooks/useIsOnScreen.ts
+++ b/src/hooks/useIsOnScreen.ts
@@ -34,7 +34,7 @@ function getScrollParent(node: HTMLElement | null): HTMLElement | typeof window 
     return null;
   }
 
-  if (node.scrollHeight > node.clientHeight) {
+  if (node.scrollHeight > node.clientHeight && node.clientHeight > 0) {
     return node.tagName === 'HTML' ? window : node;
   } else {
     return getScrollParent(node.parentElement);


### PR DESCRIPTION
E.g. the one in legacy ui-kit that is used in Studio.