### PR TITLE
feat(error-check): add check for  error message

### DIFF
--- a/src/components/SchemaRow/SchemaRow.tsx
+++ b/src/components/SchemaRow/SchemaRow.tsx
@@ -15,7 +15,15 @@ import * as React from 'react';
 import { COMBINER_NAME_MAP } from '../../consts';
 import { useJSVOptionsContext } from '../../contexts';
 import { calculateChildrenToShow, isFlattenableNode, isPropertyRequired } from '../../tree';
-import { Caret, Description, Format, getValidationsFromSchema, Types, Validations } from '../shared';
+import {
+  Caret,
+  Description,
+  Format,
+  getInternalSchemaError,
+  getValidationsFromSchema,
+  Types,
+  Validations,
+} from '../shared';
 import { ChildStack } from '../shared/ChildStack';
 import { Properties, useHasProperties } from '../shared/Properties';
 import { hoveredNodeAtom, isNodeHoveredAtom } from './state';
@@ -69,6 +77,8 @@ export const SchemaRow: React.FunctionComponent<SchemaRowProps> = React.memo(({ 
   const deprecated = isRegularNode(schemaNode) && schemaNode.deprecated;
   const validations = isRegularNode(schemaNode) ? schemaNode.validations : {};
   const hasProperties = useHasProperties({ required, deprecated, validations });
+
+  const internalSchemaError = getInternalSchemaError(schemaNode);
 
   return (
     <>
@@ -158,9 +168,13 @@ export const SchemaRow: React.FunctionComponent<SchemaRowProps> = React.memo(({ 
             hideExamples={hideExamples}
           />
 
-          {isBrokenRef && (
-            // TODO (JJ): Add mosaic tooltip showing ref error
-            <Icon title={refNode!.error!} color="danger" icon={faExclamationTriangle} size="sm" />
+          {(isBrokenRef || internalSchemaError.hasError) && (
+            <Icon
+              title={refNode?.error! || internalSchemaError.error}
+              color="danger"
+              icon={faExclamationTriangle}
+              size="sm"
+            />
           )}
         </VStack>
 

--- a/src/components/SchemaRow/TopLevelSchemaRow.tsx
+++ b/src/components/SchemaRow/TopLevelSchemaRow.tsx
@@ -1,4 +1,5 @@
 import { faCaretDown } from '@fortawesome/free-solid-svg-icons/faCaretDown.js';
+import { faExclamationTriangle } from '@fortawesome/free-solid-svg-icons/faExclamationTriangle.js';
 import { isRegularNode, RegularNode } from '@stoplight/json-schema-tree';
 import { Box, Flex, HStack, Icon, Menu, Pressable } from '@stoplight/mosaic';
 import { useUpdateAtom } from 'jotai/utils';
@@ -9,6 +10,7 @@ import { useIsOnScreen } from '../../hooks/useIsOnScreen';
 import { calculateChildrenToShow, isComplexArray } from '../../tree';
 import { showPathCrumbsAtom } from '../PathCrumbs/state';
 import { ChildStack } from '../shared/ChildStack';
+import { getInternalSchemaError } from '../shared/Validations';
 import { SchemaRow, SchemaRowProps } from './SchemaRow';
 import { useChoices } from './useChoices';
 
@@ -17,12 +19,17 @@ export const TopLevelSchemaRow = ({ schemaNode }: Pick<SchemaRowProps, 'schemaNo
   const childNodes = React.useMemo(() => calculateChildrenToShow(selectedChoice.type), [selectedChoice.type]);
   const nestingLevel = 0;
 
+  const internalSchemaError = getInternalSchemaError(schemaNode);
+
   // regular objects are flattened at the top level
   if (isRegularNode(schemaNode) && isPureObjectNode(schemaNode)) {
     return (
       <>
         <ScrollCheck />
         <ChildStack schemaNode={schemaNode} childNodes={childNodes} currentNestingLevel={nestingLevel} />
+        {internalSchemaError.hasError && (
+          <Icon title={internalSchemaError.error} color="danger" icon={faExclamationTriangle} size="sm" />
+        )}
       </>
     );
   }

--- a/src/components/__tests__/SchemaRow.spec.tsx
+++ b/src/components/__tests__/SchemaRow.spec.tsx
@@ -49,6 +49,87 @@ describe('SchemaRow component', () => {
     });
   });
 
+  describe('resolving permission error', () => {
+    let tree: RootNode;
+    let schema: JSONSchema4;
+
+    it('given an object schema is marked as internal, a permission denied error messsage should be shown', () => {
+      schema = {
+        type: 'object',
+        'x-sl-internally-excluded': true,
+        'x-sl-error-message': 'You do not have permission to view this reference',
+      };
+      tree = buildTree(schema);
+      const wrapper = mount(<SchemaRow schemaNode={tree.children[0]!} nestingLevel={0} />);
+      expect(wrapper.find(Icon).at(0)).toHaveProp('title', `You do not have permission to view this reference`);
+      wrapper.unmount();
+    });
+
+    it('given a number schema is marked as internal, a permission denied error messsage should be shown', () => {
+      schema = {
+        type: 'number',
+        'x-sl-internally-excluded': true,
+        'x-sl-error-message': 'You do not have permission to view this reference',
+      };
+      tree = buildTree(schema);
+      const wrapper = mount(<SchemaRow schemaNode={tree.children[0]!} nestingLevel={0} />);
+      expect(wrapper.find(Icon).at(0)).toHaveProp('title', `You do not have permission to view this reference`);
+      wrapper.unmount();
+    });
+
+    it('given an integer schema is marked as internal, a permission denied error messsage should be shown', () => {
+      schema = {
+        type: 'integer',
+        'x-sl-internally-excluded': true,
+        'x-sl-error-message': 'You do not have permission to view this reference',
+      };
+      tree = buildTree(schema);
+      const wrapper = mount(<SchemaRow schemaNode={tree.children[0]!} nestingLevel={0} />);
+      expect(wrapper.find(Icon).at(0)).toHaveProp('title', `You do not have permission to view this reference`);
+      wrapper.unmount();
+    });
+
+    it('given a string schema is marked as internal, a permission denied error messsage should be shown', () => {
+      schema = {
+        type: 'string',
+        'x-sl-internally-excluded': true,
+        'x-sl-error-message': 'You do not have permission to view this reference',
+      };
+      tree = buildTree(schema);
+      const wrapper = mount(<SchemaRow schemaNode={tree.children[0]!} nestingLevel={0} />);
+      expect(wrapper.find(Icon).at(0)).toHaveProp('title', `You do not have permission to view this reference`);
+      wrapper.unmount();
+    });
+
+    it('given a boolean schema is marked as internal, a permission denied error messsage should be shown', () => {
+      schema = {
+        type: 'boolean',
+        'x-sl-internally-excluded': true,
+        'x-sl-error-message': 'You do not have permission to view this reference',
+      };
+      tree = buildTree(schema);
+      const wrapper = mount(<SchemaRow schemaNode={tree.children[0]!} nestingLevel={0} />);
+      expect(wrapper.find(Icon).at(0)).toHaveProp('title', `You do not have permission to view this reference`);
+      wrapper.unmount();
+    });
+
+    it('given an array schema is marked as internal, a permission denied error messsage should be shown', () => {
+      schema = {
+        title: 'test',
+        type: 'array',
+        items: {
+          type: 'array',
+          'x-sl-internally-excluded': true,
+          'x-sl-error-message': 'You do not have permission to view this reference',
+        },
+      };
+      tree = buildTree(schema);
+      const wrapper = mount(<SchemaRow schemaNode={tree.children[0]!} nestingLevel={0} />);
+      expect(wrapper.find(Icon).at(0)).toHaveProp('title', `You do not have permission to view this reference`);
+      wrapper.unmount();
+    });
+  });
+
   describe('required property', () => {
     let schema: JSONSchema4;
 

--- a/src/components/__tests__/TopLevelSchemaRow.spec.tsx
+++ b/src/components/__tests__/TopLevelSchemaRow.spec.tsx
@@ -1,0 +1,135 @@
+import 'jest-enzyme';
+
+import { RootNode } from '@stoplight/json-schema-tree';
+import { Icon } from '@stoplight/mosaic';
+import { mount } from 'enzyme';
+import { JSONSchema4 } from 'json-schema';
+import * as React from 'react';
+
+import { TopLevelSchemaRow } from '../SchemaRow/TopLevelSchemaRow';
+import { buildTree } from '../shared/__tests__/utils';
+
+describe('resolving permission error', () => {
+  let tree: RootNode;
+  let schema: JSONSchema4;
+
+  it('given an object schema has a mixture of properties with and without x-sl-error-message, a permission denied error messsage should be shown on properties with x-sl-error-message', () => {
+    schema = {
+      title: 'User',
+      type: 'object',
+      description: '',
+      properties: {
+        id: {
+          type: 'integer',
+          description: 'Unique identifier for the given user.',
+        },
+        firstName: {
+          type: 'string',
+        },
+        mailingAddress: {
+          type: 'object',
+          'x-sl-error-message': 'You do not have permission to view this reference',
+          'x-sl-internally-excluded': true,
+        },
+        billingAddresses: {
+          type: 'array',
+          'x-sl-error-message': 'You do not have permission to view this reference',
+          'x-sl-internally-excluded': true,
+        },
+      },
+    };
+
+    tree = buildTree(schema);
+    const wrapper = mount(<TopLevelSchemaRow schemaNode={tree.children[0]!} />);
+    expect(wrapper.find(Icon).at(0)).toHaveProp('title', `You do not have permission to view this reference`);
+    expect(wrapper.find(Icon).at(1)).toHaveProp('title', `You do not have permission to view this reference`);
+    expect(wrapper.find(Icon).at(2)).not.toHaveProp('title', `You do not have permission to view this reference`);
+    expect(wrapper.find(Icon).at(3)).not.toHaveProp('title', `You do not have permission to view this reference`);
+    wrapper.unmount();
+  });
+
+  it('given an object schema with all properties containing x-sl-error-message, a permission denied error messsage should be shown for each', () => {
+    schema = {
+      title: 'User',
+      type: 'object',
+      description: '',
+      properties: {
+        mailingAddress: {
+          type: 'object',
+          'x-sl-error-message': 'You do not have permission to view this reference',
+          'x-sl-internally-excluded': true,
+        },
+        testAddress: {
+          type: 'string',
+          'x-sl-error-message': 'You do not have permission to view this reference',
+          'x-sl-internally-excluded': true,
+        },
+        billingAddresses: {
+          type: 'array',
+          'x-sl-error-message': 'You do not have permission to view this reference',
+          'x-sl-internally-excluded': true,
+        },
+      },
+    };
+
+    tree = buildTree(schema);
+    const wrapper = mount(<TopLevelSchemaRow schemaNode={tree.children[0]!} />);
+    expect(wrapper.find(Icon).at(0)).toHaveProp('title', `You do not have permission to view this reference`);
+    expect(wrapper.find(Icon).at(1)).toHaveProp('title', `You do not have permission to view this reference`);
+    expect(wrapper.find(Icon).at(2)).toHaveProp('title', `You do not have permission to view this reference`);
+    wrapper.unmount();
+  });
+
+  it('given an object schema where the toplevel contains x-sl-error-message, a permission denied error messsage should be shown', () => {
+    schema = {
+      type: 'object',
+      'x-sl-error-message': 'You do not have permission to view this reference',
+      'x-sl-internally-excluded': true,
+    };
+    tree = buildTree(schema);
+    const wrapper = mount(<TopLevelSchemaRow schemaNode={tree.children[0]!} />);
+    expect(wrapper.find(Icon).at(0)).toHaveProp('title', `You do not have permission to view this reference`);
+    wrapper.unmount();
+  });
+
+  it('given an object schema has properties without ax-sl-error-message, a permission denied error messsage should not be shown', () => {
+    schema = {
+      title: 'User',
+      type: 'object',
+      description: '',
+      properties: {
+        id: {
+          type: 'integer',
+          description: 'Unique identifier for the given user.',
+        },
+        firstName: {
+          type: 'string',
+        },
+        otherName: {
+          type: 'array',
+          items: {
+            title: 'Address',
+            type: 'object',
+            description: '',
+            properties: {
+              id: {
+                type: 'integer',
+                description: 'Unique identifier for the given user.',
+              },
+              location: {
+                type: 'string',
+              },
+            },
+          },
+        },
+      },
+    };
+
+    tree = buildTree(schema);
+    const wrapper = mount(<TopLevelSchemaRow schemaNode={tree.children[0]!} />);
+    expect(wrapper.find(Icon).at(1)).not.toHaveProp('title', `You do not have permission to view this reference`);
+    expect(wrapper.find(Icon).at(2)).not.toHaveProp('title', `You do not have permission to view this reference`);
+    expect(wrapper.find(Icon).at(3)).not.toHaveProp('title', `You do not have permission to view this reference`);
+    wrapper.unmount();
+  });
+});

--- a/src/components/shared/Validations.tsx
+++ b/src/components/shared/Validations.tsx
@@ -1,4 +1,4 @@
-import { isRegularNode, RegularNode } from '@stoplight/json-schema-tree';
+import { isRegularNode, RegularNode, SchemaNode } from '@stoplight/json-schema-tree';
 import { Flex, HStack, Text } from '@stoplight/mosaic';
 import { Dictionary } from '@stoplight/types';
 import capitalize from 'lodash/capitalize.js';
@@ -210,4 +210,27 @@ function getFilteredValidations(schemaNode: RegularNode) {
   }
 
   return schemaNode.validations;
+}
+
+export function getInternalSchemaError(schemaNode: SchemaNode, defaultErrorMessage?: string) {
+  let errorMessage: string | undefined;
+  const fragment: unknown = schemaNode.fragment;
+  if (typeof fragment === 'object' && fragment !== null) {
+    const fragmentErrorMessage = fragment['x-sl-error-message'];
+    if (typeof fragmentErrorMessage === 'string') {
+      errorMessage = fragmentErrorMessage ?? defaultErrorMessage;
+    } else {
+      const items: unknown = fragment['items'];
+      if (typeof items === 'object' && items !== null) {
+        const itemsErrorMessage = items['x-sl-error-message'];
+        if (typeof itemsErrorMessage === 'string') {
+          errorMessage = itemsErrorMessage ?? defaultErrorMessage;
+        }
+      }
+    }
+  }
+  return {
+    hasError: !!errorMessage,
+    error: errorMessage,
+  };
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

## Motivation and Context
When users are viewing public endpoints that reference internally marked schemas, we need a way to display an error message to let the user know they do not have permissions to view it.

#InsertIssueNumberHere
https://github.com/stoplightio/platform-internal/issues/10534

## Description
Added a check at the toplevelschemarow and at the schemarow levels to check for the `x-sl-error-message` property


## How Has This Been Tested?
Manually tested changes by pulling this package into platform internal and manually making changes to the schema and schema permissions and seeing if the error message showed up as expected.

Added test coverage for SchemaRow

## Screenshot(s)/recordings(s)
<img width="840" alt="Screen Shot 2022-06-02 at 9 46 40 AM" src="https://user-images.githubusercontent.com/19455540/171682127-285bc64a-4500-44e9-af48-5545040974a9.png">

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] This PR's code follows as closely as possible [the coding style/guidelines of this project](???).
- [ ] I have added error reporting and followed [the error reporting guidelines](???).
- [ ] I have added event tracking and followed [the event tracking guidelines](???).
- [ ] I have updated any relevant documentation accordingly to reflect this PR's changes.
- [ ] I have added automated tests (unit/integration/e2e/other) to cover my changes.
- [ ] All new and existing tests pass locally (excluding flaky CI tests).
<!-- It's up to the discretion of the code reviewer(s) whether or not all of these must be checked before approval. -->
