### PR TITLE
fix: combiners with differing types render nothing for some children

### DIFF
--- a/src/__fixtures__/combiners/oneof-with-multi-types.json
+++ b/src/__fixtures__/combiners/oneof-with-multi-types.json
@@ -1,0 +1,54 @@
+{
+  "title": "a",
+  "oneOf": [
+    {
+      "title": "b",
+      "type": "object",
+      "properties": {
+        "c": {
+          "title": "d",
+          "type": "string"
+        },
+        "e": {
+          "title": "e",
+          "type": "string"
+        }
+      }
+    },
+    {
+      "title": "f",
+      "type": "boolean"
+    },
+    {
+      "title": "g",
+      "oneOf": [
+        {
+          "title": "h",
+          "type": "string"
+        },
+        {
+          "title": "l",
+          "type": "object",
+          "properties": {
+            "foo": {
+              "title": "k",
+              "oneOf": [
+                {
+                  "title": "m",
+                  "type": "string"
+                },
+                {
+                  "title": "o",
+                  "type": "object",
+                  "properties": {
+                    "foo": { "type": "string" }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/__stories__/Combiners.tsx
+++ b/src/__stories__/Combiners.tsx
@@ -9,6 +9,7 @@ const allOfSchema = require('../__fixtures__/combiners/allOfs/base.json');
 const allOfComplexSchema = require('../__fixtures__/combiners/allOfs/complex.json');
 const oneOfWithArraySchema = require('../__fixtures__/combiners/oneof-with-array-type.json');
 const oneOfWithArraySchema2 = require('../__fixtures__/combiners/oneof-within-array-item.json');
+const oneOfWithMultiTypesSchema = require('../__fixtures__/combiners/oneof-with-multi-types.json');
 const anyOfObject = require('../__fixtures__/combiners/anyOf.json');
 
 export default {
@@ -31,6 +32,9 @@ ArrayOneOf.args = { schema: oneOfWithArraySchema as JSONSchema4, renderRootTreeL
 
 export const ArrayOneOf2 = Template.bind({});
 ArrayOneOf2.args = { schema: oneOfWithArraySchema2 as JSONSchema4, renderRootTreeLines: true };
+
+export const OneOfMulti = Template.bind({});
+OneOfMulti.args = { schema: oneOfWithMultiTypesSchema, renderRootTreeLines: true };
 
 export const ObjectAnyOf = Template.bind({});
 ObjectAnyOf.args = { schema: anyOfObject as JSONSchema4 };

--- a/src/components/SchemaRow/TopLevelSchemaRow.tsx
+++ b/src/components/SchemaRow/TopLevelSchemaRow.tsx
@@ -88,7 +88,11 @@ export const TopLevelSchemaRow = ({
             currentNestingLevel={nestingLevel}
             parentNodeId={nodeId}
           />
-        ) : null}
+        ) : combiner ? <SchemaRow
+                         schemaNode={selectedChoice.type}
+                         nestingLevel={nestingLevel} /> : null
+
+        }
       </>
     );
   }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

## Motivation and Context

fixes #221

## Description
<!-- Describe your technical changes in detail. -->


## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Did you test the changes locally, in a PR environment, or somewhere else? -->
<!-- Were unit/integration/e2e/other tests added? If not, why? -->
<!-- Also describe how one or more persons giving a code review can verify your changes. -->


## Screenshot(s)/recordings(s)
Before:
![image](https://github.com/stoplightio/json-schema-viewer/assets/1787231/dd4bf697-8367-4297-9d5a-a232a38c9daf)

After: 
![image](https://github.com/stoplightio/json-schema-viewer/assets/1787231/d2c136bd-0cb0-48b1-91f8-1ea584f1f6a5)


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] This PR's code follows as closely as possible [the coding style/guidelines of this project](???).
- [ ] I have added error reporting and followed [the error reporting guidelines](???).
- [ ] I have added event tracking and followed [the event tracking guidelines](???).
- [ ] I have updated any relevant documentation accordingly to reflect this PR's changes.
- [ ] I have added automated tests (unit/integration/e2e/other) to cover my changes.
- [ ] All new and existing tests pass locally (excluding flaky CI tests).
<!-- It's up to the discretion of the code reviewer(s) whether or not all of these must be checked before approval. -->
