### PR TITLE
fix: display title instead of any for combiners

### DIFF
--- a/src/__fixtures__/combiners/oneof-with-multi-types.json
+++ b/src/__fixtures__/combiners/oneof-with-multi-types.json
@@ -1,0 +1,54 @@
+{
+  "title": "a",
+  "oneOf": [
+    {
+      "title": "b",
+      "type": "object",
+      "properties": {
+        "c": {
+          "title": "d",
+          "type": "string"
+        },
+        "e": {
+          "title": "e",
+          "type": "string"
+        }
+      }
+    },
+    {
+      "title": "f",
+      "type": "boolean"
+    },
+    {
+      "title": "g",
+      "oneOf": [
+        {
+          "title": "h",
+          "type": "string"
+        },
+        {
+          "title": "l",
+          "type": "object",
+          "properties": {
+            "foo": {
+              "title": "k",
+              "oneOf": [
+                {
+                  "title": "m",
+                  "type": "string"
+                },
+                {
+                  "title": "o",
+                  "type": "object",
+                  "properties": {
+                    "foo": { "type": "string" }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/__stories__/Combiners.tsx
+++ b/src/__stories__/Combiners.tsx
@@ -9,6 +9,7 @@ const allOfSchema = require('../__fixtures__/combiners/allOfs/base.json');
 const allOfComplexSchema = require('../__fixtures__/combiners/allOfs/complex.json');
 const oneOfWithArraySchema = require('../__fixtures__/combiners/oneof-with-array-type.json');
 const oneOfWithArraySchema2 = require('../__fixtures__/combiners/oneof-within-array-item.json');
+const oneOfWithMultiTypesSchema = require('../__fixtures__/combiners/oneof-with-multi-types.json');
 const anyOfObject = require('../__fixtures__/combiners/anyOf.json');
 
 export default {
@@ -28,6 +29,9 @@ CircularAllOf.args = { schema: allOfComplexSchema as JSONSchema4 };
 
 export const ArrayOneOf = Template.bind({});
 ArrayOneOf.args = { schema: oneOfWithArraySchema as JSONSchema4, renderRootTreeLines: true };
+
+export const OneOfMulti = Template.bind({});
+OneOfMulti.args = { schema: oneOfWithMultiTypesSchema, renderRootTreeLines: true };
 
 export const ArrayOneOf2 = Template.bind({});
 ArrayOneOf2.args = { schema: oneOfWithArraySchema2 as JSONSchema4, renderRootTreeLines: true };

--- a/src/components/SchemaRow/useChoices.ts
+++ b/src/components/SchemaRow/useChoices.ts
@@ -18,7 +18,7 @@ function calculateChoiceTitle(node: SchemaNode, isPlural: boolean): string {
     if (realName) {
       return realName;
     }
-    return node.primaryType !== null ? node.primaryType + primitiveSuffix : 'any';
+    return node.primaryType !== null ? node.primaryType + primitiveSuffix : node.originalFragment.title as string || 'any';
   }
   if (isReferenceNode(node)) {
     if (node.value) {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
#InsertIssueNumberHere

fixes #223 

## Description
<!-- Describe your technical changes in detail. -->
When rendering a combiner's children, we want to show the title if there is one.

## How Has This Been Tested?
with the provided schema fixture inside of storybook

## Screenshot(s)/recordings(s)
see linked issue


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] This PR's code follows as closely as possible [the coding style/guidelines of this project](???).
- [ ] I have added error reporting and followed [the error reporting guidelines](???).
- [ ] I have added event tracking and followed [the event tracking guidelines](???).
- [ ] I have updated any relevant documentation accordingly to reflect this PR's changes.
- [ ] I have added automated tests (unit/integration/e2e/other) to cover my changes.
- [ ] All new and existing tests pass locally (excluding flaky CI tests).
<!-- It's up to the discretion of the code reviewer(s) whether or not all of these must be checked before approval. -->
