### PR TITLE
fix: add data-test attribute for descriptions

### DIFF
--- a/src/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/src/__tests__/__snapshots__/index.spec.tsx.snap
@@ -278,7 +278,7 @@ exports[`HTML Output given anyOf combiner placed next to allOf given allOf mergi
                 <span data-test=\\"property-type\\">boolean</span>
               </div>
             </div>
-            <div style=\\"font-size: 12px\\"><p>Is this account enabled</p></div>
+            <div data-test=\\"property-description\\" style=\\"font-size: 12px\\"><p>Is this account enabled</p></div>
           </div>
         </div>
         <div data-id=\\"bd5c934660dce\\" data-test=\\"schema-row\\">
@@ -361,7 +361,7 @@ exports[`HTML Output given complex type that includes array and complex array su
                 </div>
               </div>
             </div>
-            <div style=\\"font-size: 12px\\">
+            <div data-test=\\"property-description\\" style=\\"font-size: 12px\\">
               <p>
                 This description can be long and should truncate once it reaches the end of the row. If it's not
                 truncating then theres and issue that needs to be fixed. Help!
@@ -453,7 +453,7 @@ exports[`HTML Output given oneOf combiner placed next to allOf given allOf mergi
                 <span data-test=\\"property-type\\">boolean</span>
               </div>
             </div>
-            <div style=\\"font-size: 12px\\"><p>Is this account enabled</p></div>
+            <div data-test=\\"property-description\\" style=\\"font-size: 12px\\"><p>Is this account enabled</p></div>
           </div>
         </div>
         <div data-id=\\"bd5c934660dce\\" data-test=\\"schema-row\\">
@@ -704,7 +704,9 @@ exports[`HTML Output top level descriptions should render top-level description 
   <div data-overlay-container=\\"true\\">
     <div class=\\"JsonSchemaViewer\\">
       <div></div>
-      <div style=\\"font-size: 12px\\"><p>This is a description that should be rendered</p></div>
+      <div data-test=\\"property-description\\" style=\\"font-size: 12px\\">
+        <p>This is a description that should be rendered</p>
+      </div>
       <div data-level=\\"0\\">
         <div data-id=\\"862ab7c3a6663\\" data-test=\\"schema-row\\">
           <div>

--- a/src/components/shared/Description.tsx
+++ b/src/components/shared/Description.tsx
@@ -13,6 +13,7 @@ export const Description: React.FunctionComponent<{ value: unknown }> = ({ value
     return (
       <Box
         as={MarkdownViewer}
+        data-test="property-description"
         markdown={value}
         style={{
           fontSize: 12,


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Add `data-test` for descriptions

## Description
<!-- Describe your technical changes in detail. -->


## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Did you test the changes locally, in a PR environment, or somewhere else? -->
<!-- Were unit/integration/e2e/other tests added? If not, why? -->
<!-- Also describe how one or more persons giving a code review can verify your changes. -->


## Screenshot(s)/recordings(s)
<!-- If applicable, add screenshots or gifs to help demonstrate the changes. -->
<!-- If not applicable, remove this screenshots section before creating the PR. -->


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] This PR's code follows as closely as possible [the coding style/guidelines of this project](???).
- [ ] I have added error reporting and followed [the error reporting guidelines](???).
- [ ] I have added event tracking and followed [the event tracking guidelines](???).
- [ ] I have updated any relevant documentation accordingly to reflect this PR's changes.
- [ ] I have added automated tests (unit/integration/e2e/other) to cover my changes.
- [x] All new and existing tests pass locally (excluding flaky CI tests).
<!-- It's up to the discretion of the code reviewer(s) whether or not all of these must be checked before approval. -->
