### PR TITLE
export useChoices and other utilities for elements

### DIFF
--- a/src/__fixtures__/combiners/oneof-with-allof-children.json
+++ b/src/__fixtures__/combiners/oneof-with-allof-children.json
@@ -1,0 +1,44 @@
+{
+  "oneOf": [
+    {
+      "allOf": [
+        {
+          "type": "object",
+          "properties": {
+            "foo": {
+              "type": "string"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "bar": {
+              "type": "number"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "allOf": [
+        {
+          "type": "object",
+          "properties": {
+            "baz": {
+              "type": "string"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "boggle": {
+              "type": "number"
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/components/SchemaRow/SchemaRow.tsx
+++ b/src/components/SchemaRow/SchemaRow.tsx
@@ -9,7 +9,7 @@ import * as React from 'react';
 import { COMBINER_NAME_MAP } from '../../consts';
 import { useJSVOptionsContext } from '../../contexts';
 import { getNodeId, getOriginalNodeId } from '../../hash';
-import { visibleChildren, isPropertyRequired } from '../../tree';
+import { isPropertyRequired, visibleChildren } from '../../tree';
 import { Caret, Description, getValidationsFromSchema, Types, Validations } from '../shared';
 import { ChildStack } from '../shared/ChildStack';
 import { Error } from '../shared/Error';

--- a/src/components/SchemaRow/SchemaRow.tsx
+++ b/src/components/SchemaRow/SchemaRow.tsx
@@ -9,7 +9,7 @@ import * as React from 'react';
 import { COMBINER_NAME_MAP } from '../../consts';
 import { useJSVOptionsContext } from '../../contexts';
 import { getNodeId, getOriginalNodeId } from '../../hash';
-import { calculateChildrenToShow, isPropertyRequired } from '../../tree';
+import { visibleChildren, isPropertyRequired } from '../../tree';
 import { Caret, Description, getValidationsFromSchema, Types, Validations } from '../shared';
 import { ChildStack } from '../shared/ChildStack';
 import { Error } from '../shared/Error';
@@ -55,7 +55,7 @@ export const SchemaRow: React.FunctionComponent<SchemaRowProps> = React.memo(
     const description = isRegularNode(typeToShow) ? typeToShow.annotations.description : null;
 
     const rootLevel = renderRootTreeLines ? 1 : 2;
-    const childNodes = React.useMemo(() => calculateChildrenToShow(typeToShow), [typeToShow]);
+    const childNodes = React.useMemo(() => visibleChildren(typeToShow), [typeToShow]);
     const combiner = isRegularNode(schemaNode) && schemaNode.combiners?.length ? schemaNode.combiners[0] : null;
     const isCollapsible = childNodes.length > 0;
     const isRootLevel = nestingLevel < rootLevel;

--- a/src/components/SchemaRow/TopLevelSchemaRow.tsx
+++ b/src/components/SchemaRow/TopLevelSchemaRow.tsx
@@ -20,8 +20,6 @@ export const TopLevelSchemaRow = ({
 }: Pick<SchemaRowProps, 'schemaNode'> & { skipDescription?: boolean }) => {
   const { selectedChoice, setSelectedChoice, choices } = useChoices(schemaNode);
   const childNodes = React.useMemo(() => visibleChildren(selectedChoice.type), [selectedChoice.type]);
-  // eslint-disable-next-line no-console
-  console.log({ childNodes });
   const nestingLevel = 0;
 
   const nodeId = schemaNode.fragment?.['x-stoplight']?.id;

--- a/src/components/SchemaRow/TopLevelSchemaRow.tsx
+++ b/src/components/SchemaRow/TopLevelSchemaRow.tsx
@@ -6,7 +6,7 @@ import * as React from 'react';
 
 import { COMBINER_NAME_MAP } from '../../consts';
 import { useIsOnScreen } from '../../hooks/useIsOnScreen';
-import { calculateChildrenToShow, isComplexArray } from '../../tree';
+import { isComplexArray, visibleChildren } from '../../tree';
 import { showPathCrumbsAtom } from '../PathCrumbs/state';
 import { Description, getValidationsFromSchema, Validations } from '../shared';
 import { ChildStack } from '../shared/ChildStack';
@@ -19,7 +19,9 @@ export const TopLevelSchemaRow = ({
   skipDescription,
 }: Pick<SchemaRowProps, 'schemaNode'> & { skipDescription?: boolean }) => {
   const { selectedChoice, setSelectedChoice, choices } = useChoices(schemaNode);
-  const childNodes = React.useMemo(() => calculateChildrenToShow(selectedChoice.type), [selectedChoice.type]);
+  const childNodes = React.useMemo(() => visibleChildren(selectedChoice.type), [selectedChoice.type]);
+  // eslint-disable-next-line no-console
+  console.log({ childNodes });
   const nestingLevel = 0;
 
   const nodeId = schemaNode.fragment?.['x-stoplight']?.id;

--- a/src/components/SchemaRow/index.ts
+++ b/src/components/SchemaRow/index.ts
@@ -1,2 +1,3 @@
 export * from './SchemaRow';
 export * from './TopLevelSchemaRow';
+export { Choice, useChoices } from './useChoices';

--- a/src/components/SchemaRow/useChoices.ts
+++ b/src/components/SchemaRow/useChoices.ts
@@ -6,7 +6,8 @@ import * as React from 'react';
 import { isComplexArray, isNonEmptyParentNode } from '../../tree';
 import { printName } from '../../utils';
 
-type Choice = {
+/** one option among several mutually exclusive sub-schemas */
+export type Choice = {
   title: string;
   type: SchemaNode;
 };
@@ -53,10 +54,11 @@ function makeArrayChoice(node: SchemaNode, combiner?: string): Choice {
 }
 
 /**
- * Calculates type choices for a given node.
+ * Enumerates the sub-schema type for a given node.
  *
- * Usually a node has one choice - only one possible type -, itself.
- * If a node is an oneOf or anyOf combiner, the possible types are the sub-types of the combiner.
+ * Usually a node has one choice, only one possible type: itself. If a node is
+ * a oneOf or anyOf combiner, the possible types are the sub-types of the
+ * combiner.
  */
 export const useChoices = (schemaNode: SchemaNode) => {
   const choices: Choice[] = React.useMemo(() => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
-export { JsonSchemaViewer, Validations } from './components';
+export { Choice, JsonSchemaViewer, useChoices, Validations } from './components';
+export { visibleChildren } from './tree';
 export * from './types';

--- a/src/tree/utils.ts
+++ b/src/tree/utils.ts
@@ -41,10 +41,11 @@ export function isComplexArray(node: SchemaNode): node is ComplexArrayNode {
 }
 
 /**
- * Returns the children of `node` that should be displayed in the tree.
- * Defaults to `node.children`, except for Arrays that get special handling (flattening).
+ * Returns the children of `node` that should be displayed in a viewer or
+ * editor. Defaults to `node.children`, except for Arrays that get special
+ * handling (flattening).
  */
-export function calculateChildrenToShow(node: SchemaNode): SchemaNode[] {
+export function visibleChildren(node: SchemaNode): SchemaNode[] {
   if (!isRegularNode(node) || isPrimitiveArray(node)) {
     return [];
   }


### PR DESCRIPTION
## Motivation and Context
https://github.com/stoplightio/platform-internal/issues/18370

json-schema-viewer and TryIt have been using different logic to determine if/how to display form-encoded schemas that have a `oneOf` combiner at the top level.

## Description
Expose a few utility features for use by related, downstream tools that also render JSON Schema in one way or another. 
 Specifically, the TryIt function of Elements will be able to reuse the same logic -- and thereby get the same visible results -- as json-schema-viewer.

## How Has This Been Tested?
Existing functionality is being exported; no functional changes were made.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] This PR's code follows as closely as possible [the coding style/guidelines of this project](???).
- [ ] I have added error reporting and followed [the error reporting guidelines](???).
- [ ] I have added event tracking and followed [the event tracking guidelines](???).
- [x] I have updated any relevant documentation accordingly to reflect this PR's changes.
- [ ] I have added automated tests (unit/integration/e2e/other) to cover my changes.
- [x] All new and existing tests pass locally (excluding flaky CI tests).
