### PR TITLE
feat: add ability to Expand/Collapse All

### DIFF
--- a/src/__stories__/Default.tsx
+++ b/src/__stories__/Default.tsx
@@ -7,6 +7,7 @@ import { JsonSchemaProps, JsonSchemaViewer } from '../components/JsonSchemaViewe
 
 const defaultSchema = require('../__fixtures__/default-schema.json');
 const stressSchema = require('../__fixtures__/stress-schema.json');
+const githubIssueSchema = require('../__fixtures__/real-world/github-issue.json');
 const arrayOfComplexObjects = require('../__fixtures__/arrays/of-complex-objects.json');
 
 export default {
@@ -22,12 +23,16 @@ export const Default = Template.bind({});
 
 export const CustomRowAddon = Template.bind({});
 CustomRowAddon.args = {
-  renderRowAddon: () => (
-    <Flex h="full" alignItems="center">
-      <Button pl={1} mr={1} size="sm" appearance="minimal" icon="bullseye" />
-      <input type="checkbox" />
-    </Flex>
-  ),
+  renderRowAddon: ({ nestingLevel }) => {
+    return nestingLevel == 1 ? (
+      <Flex h="full" alignItems="center">
+        <Button pl={1} mr={1} size="sm" appearance="minimal" icon="bullseye" />
+        <Button pl={1} mr={1} size="sm" appearance="minimal">
+          Expand All
+        </Button>
+      </Flex>
+    ) : null;
+  },
 };
 
 export const Expansions = Template.bind({});
@@ -88,3 +93,10 @@ export const DarkMode: Story<JsonSchemaProps> = ({ schema = defaultSchema as JSO
     </Box>
   </InvertTheme>
 );
+
+export const ExpandCollapseAll = Template.bind({});
+ExpandCollapseAll.args = {
+  showExpandAll: true,
+  schema: githubIssueSchema as JSONSchema4,
+};
+ExpandCollapseAll.storyName = 'Expand/Collapse All';

--- a/src/components/JsonSchemaViewer.tsx
+++ b/src/components/JsonSchemaViewer.tsx
@@ -4,11 +4,10 @@ import {
   SchemaTree as JsonSchemaTree,
   SchemaTreeRefDereferenceFn,
 } from '@stoplight/json-schema-tree';
-import { Box, Provider as MosaicProvider } from '@stoplight/mosaic';
+import { Box, Button, HStack, Provider as MosaicProvider } from '@stoplight/mosaic';
 import { ErrorBoundaryForwardedProps, FallbackProps, withErrorBoundary } from '@stoplight/react-error-boundary';
 import cn from 'classnames';
-import { Provider } from 'jotai';
-import { useUpdateAtom } from 'jotai/utils';
+import { Provider, useAtom, useSetAtom } from 'jotai';
 import * as React from 'react';
 
 import { JSVOptions, JSVOptionsContextProvider } from '../contexts';
@@ -16,7 +15,7 @@ import { shouldNodeBeIncluded } from '../tree/utils';
 import { JSONSchema } from '../types';
 import { PathCrumbs } from './PathCrumbs';
 import { TopLevelSchemaRow } from './SchemaRow';
-import { hoveredNodeAtom } from './SchemaRow/state';
+import { ExpansionMode, expansionModeAtom, hoveredNodeAtom } from './SchemaRow/state';
 
 export type JsonSchemaProps = Partial<JSVOptions> & {
   schema: JSONSchema;
@@ -29,11 +28,13 @@ export type JsonSchemaProps = Partial<JSVOptions> & {
   maxHeight?: number;
   parentCrumbs?: string[];
   skipTopLevelDescription?: boolean;
+  showExpandAll?: boolean;
 };
 
 const JsonSchemaViewerComponent = ({
   viewMode = 'standalone',
   defaultExpandedDepth = 1,
+  showExpandAll = false,
   onGoToRef,
   renderRowAddon,
   renderExtensionAddon,
@@ -48,6 +49,7 @@ const JsonSchemaViewerComponent = ({
     () => ({
       defaultExpandedDepth,
       viewMode,
+      showExpandAll,
       onGoToRef,
       renderRowAddon,
       renderExtensionAddon,
@@ -59,6 +61,7 @@ const JsonSchemaViewerComponent = ({
     [
       defaultExpandedDepth,
       viewMode,
+      showExpandAll,
       onGoToRef,
       renderRowAddon,
       renderExtensionAddon,
@@ -73,7 +76,12 @@ const JsonSchemaViewerComponent = ({
     <MosaicProvider>
       <JSVOptionsContextProvider value={options}>
         <Provider>
-          <JsonSchemaViewerInner viewMode={viewMode} skipTopLevelDescription={skipTopLevelDescription} {...rest} />
+          <JsonSchemaViewerInner
+            viewMode={viewMode}
+            showExpandAll={showExpandAll}
+            skipTopLevelDescription={skipTopLevelDescription}
+            {...rest}
+          />
         </Provider>
       </JSVOptionsContextProvider>
     </MosaicProvider>
@@ -83,6 +91,7 @@ const JsonSchemaViewerComponent = ({
 const JsonSchemaViewerInner = ({
   schema,
   viewMode,
+  showExpandAll,
   className,
   resolveRef,
   maxRefDepth,
@@ -95,6 +104,7 @@ const JsonSchemaViewerInner = ({
   JsonSchemaProps,
   | 'schema'
   | 'viewMode'
+  | 'showExpandAll'
   | 'className'
   | 'resolveRef'
   | 'maxRefDepth'
@@ -104,10 +114,17 @@ const JsonSchemaViewerInner = ({
   | 'parentCrumbs'
   | 'skipTopLevelDescription'
 >) => {
-  const setHoveredNode = useUpdateAtom(hoveredNodeAtom);
+  const setHoveredNode = useSetAtom(hoveredNodeAtom);
+  const [expansionMode, setExpansionMode] = useAtom(expansionModeAtom);
+
   const onMouseLeave = React.useCallback(() => {
     setHoveredNode(null);
   }, [setHoveredNode]);
+
+  const onCollapseExpandAll = React.useCallback(() => {
+    const newExpansionMode: ExpansionMode = expansionMode === 'expand_all' ? 'collapse_all' : 'expand_all';
+    setExpansionMode(newExpansionMode);
+  }, [expansionMode, setExpansionMode]);
 
   const { jsonSchemaTreeRoot, nodeCount } = React.useMemo(() => {
     const jsonSchemaTree = new JsonSchemaTree(schema, {
@@ -123,6 +140,7 @@ const JsonSchemaViewerInner = ({
         nodeCount++;
         return true;
       }
+
       return false;
     });
     jsonSchemaTree.populate();
@@ -144,6 +162,7 @@ const JsonSchemaViewerInner = ({
     () => jsonSchemaTreeRoot.children.every(node => !isRegularNode(node) || node.unknown),
     [jsonSchemaTreeRoot],
   );
+
   if (isEmpty) {
     return (
       <Box className={cn(className, 'JsonSchemaViewer')} fontSize="sm" data-test="empty-text">
@@ -160,7 +179,15 @@ const JsonSchemaViewerInner = ({
       onMouseLeave={onMouseLeave}
       style={{ maxHeight }}
     >
-      <PathCrumbs parentCrumbs={parentCrumbs} />
+      {showExpandAll ? (
+        <HStack w="full" fontFamily="mono" fontSize="sm" lineHeight="none" bg="canvas-pure" px="px" color="light">
+          <Box flex={1}>&nbsp;</Box>
+          <Button pl={1} mr={1} size="sm" appearance="minimal" onClick={onCollapseExpandAll}>
+            {expansionMode === 'expand_all' ? 'Collapse All' : 'Expand All'}
+          </Button>
+        </HStack>
+      ) : null}
+      <PathCrumbs parentCrumbs={parentCrumbs} showExpandAll={showExpandAll} />
       <TopLevelSchemaRow schemaNode={jsonSchemaTreeRoot.children[0]} skipDescription={skipTopLevelDescription} />
     </Box>
   );

--- a/src/components/PathCrumbs/index.tsx
+++ b/src/components/PathCrumbs/index.tsx
@@ -1,14 +1,27 @@
-import { Box, HStack } from '@stoplight/mosaic';
+import { Box, Button, HStack } from '@stoplight/mosaic';
 import { useAtom } from 'jotai';
 import * as React from 'react';
 
 import { useJSVOptionsContext } from '../../contexts';
+import { ExpansionMode, expansionModeAtom } from '../SchemaRow/state';
 import { pathCrumbsAtom, showPathCrumbsAtom } from './state';
 
-export const PathCrumbs = ({ parentCrumbs = [] }: { parentCrumbs?: string[] }) => {
+export const PathCrumbs = ({
+  parentCrumbs = [],
+  showExpandAll = false,
+}: {
+  parentCrumbs?: string[];
+  showExpandAll?: boolean;
+}) => {
   const [showPathCrumbs] = useAtom(showPathCrumbsAtom);
   const [pathCrumbs] = useAtom(pathCrumbsAtom);
+  const [expansionMode, setExpansionMode] = useAtom(expansionModeAtom);
   const { disableCrumbs } = useJSVOptionsContext();
+
+  const onCollapseExpandAll = React.useCallback(() => {
+    const newExpansionMode: ExpansionMode = expansionMode === 'expand_all' ? 'collapse_all' : 'expand_all';
+    setExpansionMode(newExpansionMode);
+  }, [expansionMode, setExpansionMode]);
 
   if (disableCrumbs) {
     return null;
@@ -39,8 +52,6 @@ export const PathCrumbs = ({ parentCrumbs = [] }: { parentCrumbs?: string[] }) =
 
   return (
     <HStack
-      spacing={1}
-      divider={<Box>/</Box>}
       h="md"
       // so that the crumbs take up no space in the dom, and thus do not push content down when they appear
       mt={-8}
@@ -56,8 +67,31 @@ export const PathCrumbs = ({ parentCrumbs = [] }: { parentCrumbs?: string[] }) =
       color="light"
       alignItems="center"
     >
-      {parentCrumbElems}
-      {pathCrumbElems.length && <HStack divider={<Box fontWeight="bold">.</Box>}>{pathCrumbElems}</HStack>}
+      <HStack
+        spacing={1}
+        divider={<Box>/</Box>}
+        w="full"
+        h="md"
+        borderB
+        fontFamily="mono"
+        fontSize="sm"
+        lineHeight="none"
+        bg="canvas-pure"
+        px="px"
+        color="light"
+        alignItems="center"
+        justifyContent="between"
+      >
+        {parentCrumbElems}
+        {pathCrumbElems.length && <HStack divider={<Box fontWeight="bold">.</Box>}>{pathCrumbElems}</HStack>}
+      </HStack>
+      {showExpandAll ? (
+        <Box flex={1}>
+          <Button pl={1} mr={1} size="sm" appearance="minimal" onClick={onCollapseExpandAll}>
+            {expansionMode === 'expand_all' ? 'Collapse All' : 'Expand All'}
+          </Button>
+        </Box>
+      ) : null}
     </HStack>
   );
 };

--- a/src/components/SchemaRow/SchemaRow.tsx
+++ b/src/components/SchemaRow/SchemaRow.tsx
@@ -1,8 +1,7 @@
 import { isMirroredNode, isReferenceNode, isRegularNode, SchemaNode } from '@stoplight/json-schema-tree';
 import { Box, Flex, NodeAnnotation, Select, SpaceVals, VStack } from '@stoplight/mosaic';
 import type { ChangeType } from '@stoplight/types';
-import { Atom } from 'jotai';
-import { useAtomValue, useUpdateAtom } from 'jotai/utils';
+import { Atom, useAtomValue, useSetAtom } from 'jotai';
 import last from 'lodash/last.js';
 import * as React from 'react';
 
@@ -15,7 +14,7 @@ import { Caret, Description, getValidationsFromSchema, Types, Validations } from
 import { ChildStack } from '../shared/ChildStack';
 import { Error } from '../shared/Error';
 import { Properties, useHasProperties } from '../shared/Properties';
-import { hoveredNodeAtom, isNodeHoveredAtom } from './state';
+import { expansionModeAtom, hoveredNodeAtom, isNodeHoveredAtom } from './state';
 import { useChoices } from './useChoices';
 
 export interface SchemaRowProps {
@@ -39,7 +38,9 @@ export const SchemaRow: React.FunctionComponent<SchemaRowProps> = React.memo(
       viewMode,
     } = useJSVOptionsContext();
 
-    const setHoveredNode = useUpdateAtom(hoveredNodeAtom);
+    const setHoveredNode = useSetAtom(hoveredNodeAtom);
+
+    const expansionMode = useAtomValue(expansionModeAtom);
 
     const nodeId = getNodeId(schemaNode, parentNodeId);
 
@@ -49,7 +50,7 @@ export const SchemaRow: React.FunctionComponent<SchemaRowProps> = React.memo(
     const hasChanged = nodeHasChanged?.({ nodeId: originalNodeId, mode });
 
     const [isExpanded, setExpanded] = React.useState<boolean>(
-      !isMirroredNode(schemaNode) && nestingLevel <= defaultExpandedDepth,
+      expansionMode === 'expand_all' ? true : !isMirroredNode(schemaNode) && nestingLevel <= defaultExpandedDepth,
     );
 
     const { selectedChoice, setSelectedChoice, choices } = useChoices(schemaNode);
@@ -66,6 +67,14 @@ export const SchemaRow: React.FunctionComponent<SchemaRowProps> = React.memo(
     const deprecated = isRegularNode(schemaNode) && schemaNode.deprecated;
     const validations = isRegularNode(schemaNode) ? schemaNode.validations : {};
     const hasProperties = useHasProperties({ required, deprecated, validations });
+
+    React.useEffect(() => {
+      if (expansionMode === 'expand_all' && !isExpanded) {
+        setExpanded(true);
+      } else if (expansionMode === 'collapse_all' && isExpanded) {
+        setExpanded(false);
+      }
+    }, [isExpanded, expansionMode]);
 
     const [totalVendorExtensions, vendorExtensions] = React.useMemo(
       () => extractVendorExtensions(schemaNode.fragment),

--- a/src/components/SchemaRow/TopLevelSchemaRow.tsx
+++ b/src/components/SchemaRow/TopLevelSchemaRow.tsx
@@ -1,7 +1,7 @@
 import { isPlainObject } from '@stoplight/json';
 import { isRegularNode, RegularNode } from '@stoplight/json-schema-tree';
 import { Box, Flex, HStack, Icon, Menu, Pressable } from '@stoplight/mosaic';
-import { useUpdateAtom } from 'jotai/utils';
+import { useSetAtom } from 'jotai';
 import { isEmpty } from 'lodash';
 import * as React from 'react';
 
@@ -22,7 +22,6 @@ export const TopLevelSchemaRow = ({
   skipDescription,
 }: Pick<SchemaRowProps, 'schemaNode'> & { skipDescription?: boolean }) => {
   const { renderExtensionAddon } = useJSVOptionsContext();
-
   const { selectedChoice, setSelectedChoice, choices } = useChoices(schemaNode);
   const childNodes = React.useMemo(() => visibleChildren(selectedChoice.type), [selectedChoice.type]);
   const nestingLevel = 0;
@@ -150,7 +149,7 @@ function ScrollCheck() {
   const elementRef = React.useRef<HTMLDivElement>(null);
 
   const isOnScreen = useIsOnScreen(elementRef);
-  const setShowPathCrumbs = useUpdateAtom(showPathCrumbsAtom);
+  const setShowPathCrumbs = useSetAtom(showPathCrumbsAtom);
   React.useEffect(() => {
     setShowPathCrumbs(!isOnScreen);
   }, [isOnScreen, setShowPathCrumbs]);

--- a/src/components/SchemaRow/state.ts
+++ b/src/components/SchemaRow/state.ts
@@ -2,6 +2,9 @@ import { SchemaNode } from '@stoplight/json-schema-tree';
 import { atom } from 'jotai';
 import { atomFamily } from 'jotai/utils';
 
+export type ExpansionMode = 'expand_all' | 'collapse_all' | 'off';
+
+export const expansionModeAtom = atom<ExpansionMode>('off');
 export const hoveredNodeAtom = atom<SchemaNode | null>(null);
 export const isNodeHoveredAtom = atomFamily((node: SchemaNode) => atom(get => node === get(hoveredNodeAtom)));
 export const isChildNodeHoveredAtom = atomFamily((parent: SchemaNode) =>

--- a/src/contexts/jsvOptions.tsx
+++ b/src/contexts/jsvOptions.tsx
@@ -6,6 +6,7 @@ import { ExtensionAddonRenderer, GoToRefHandler, RowAddonRenderer, ViewMode } fr
 export type JSVOptions = {
   defaultExpandedDepth: number;
   viewMode: ViewMode;
+  showExpandAll?: boolean;
   onGoToRef?: GoToRefHandler;
   renderRowAddon?: RowAddonRenderer;
   renderExtensionAddon?: ExtensionAddonRenderer;
@@ -19,6 +20,7 @@ const JSVOptionsContext = React.createContext<JSVOptions>({
   defaultExpandedDepth: 0,
   viewMode: 'standalone',
   hideExamples: false,
+  showExpandAll: false,
 });
 
 export const useJSVOptionsContext = () => React.useContext(JSVOptionsContext);


### PR DESCRIPTION
## Motivation and Context
Our documentation consumers wished to have the ability to quickly expand or collapse all the collapsible rows of the schema.

## Description
This introduces a new property named `showExpandAll` (defaults to `false`) that display a button that allows to easily expand or collapse all rows.

The button shows up in both the breadcrumbs toolbar as above the top schema row.

Replace `jotai` related deprecated functions to the suggested new alternative functions to avoid the spamming of deprecation warnings in the developer console.

## How Has This Been Tested?
This has been tested via fork of the component at work as part of our API reference documentation.

## Screenshot(s)/recordings(s)
<!-- If applicable, add screenshots or gifs to help demonstrate the changes. -->
<!-- If not applicable, remove this screenshots section before creating the PR. -->
![CleanShot 2024-07-26 at 19 01 49](https://github.com/user-attachments/assets/c81dcc9f-2c77-47f4-9e7b-3c0c716f47c3)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] This PR's code follows as closely as possible [the coding style/guidelines of this project](???).
- [ ] I have added error reporting and followed [the error reporting guidelines](???).
- [ ] I have added event tracking and followed [the event tracking guidelines](???).
- [ ] I have updated any relevant documentation accordingly to reflect this PR's changes.
- [ ] I have added automated tests (unit/integration/e2e/other) to cover my changes.
- [X] All new and existing tests pass locally (excluding flaky CI tests).
<!-- It's up to the discretion of the code reviewer(s) whether or not all of these must be checked before approval. -->
