### PR TITLE
fix: Don't display int64 range in docs

### DIFF
--- a/src/components/shared/Validations.tsx
+++ b/src/components/shared/Validations.tsx
@@ -72,8 +72,7 @@ const validationFormatters: Record<string, (value: unknown) => ValidationFormat 
   default: createValidationsFormatter('Default', { exact: true, nowrap: true }),
   style: createValidationsFormatter('Style', { exact: true, nowrap: true }),
 };
-// eslint-disable-next-line no-console
-console.log('harshita')
+
 
 const oasFormats = {
 

--- a/src/components/shared/Validations.tsx
+++ b/src/components/shared/Validations.tsx
@@ -72,15 +72,18 @@ const validationFormatters: Record<string, (value: unknown) => ValidationFormat 
   default: createValidationsFormatter('Default', { exact: true, nowrap: true }),
   style: createValidationsFormatter('Style', { exact: true, nowrap: true }),
 };
+// eslint-disable-next-line no-console
+console.log('harshita')
 
 const oasFormats = {
+
   int32: {
     minimum: 0 - 2 ** 31,
     maximum: 2 ** 31 - 1,
   },
   int64: {
-    minimum: 0 - 2 ** 63,
-    maximum: 2 ** 63 - 1,
+    minimum: Number.MIN_SAFE_INTEGER,
+    maximum: Number.MAX_SAFE_INTEGER,
   },
   float: {
     minimum: 0 - 2 ** 128,

--- a/src/components/shared/__tests__/Validations.spec.tsx
+++ b/src/components/shared/__tests__/Validations.spec.tsx
@@ -128,7 +128,7 @@ describe('Validations component', () => {
       expect(wrapper).toHaveTextContent('>= 0');
     });
 
-    it('Not defined range, should not render any validation', () => {
+    it('should not render any range if not defined', () => {
       const node = new RegularNode({
         type: 'integer',
         format: 'int64',

--- a/src/components/shared/__tests__/Validations.spec.tsx
+++ b/src/components/shared/__tests__/Validations.spec.tsx
@@ -127,5 +127,17 @@ describe('Validations component', () => {
 
       expect(wrapper).toHaveTextContent('>= 0');
     });
+
+    it('Not defined range, should not render any validation', () => {
+      const node = new RegularNode({
+        type: 'integer',
+        format: 'int64',
+      });
+
+      const validations = getValidationsFromSchema(node);
+      const wrapper = render(<Validations validations={validations} />).container;
+
+      expect(wrapper).toHaveTextContent('');
+    });
   });
 });

--- a/src/components/shared/__tests__/Validations.spec.tsx
+++ b/src/components/shared/__tests__/Validations.spec.tsx
@@ -127,17 +127,5 @@ describe('Validations component', () => {
 
       expect(wrapper).toHaveTextContent('>= 0');
     });
-
-    it('should not render any range if not defined', () => {
-      const node = new RegularNode({
-        type: 'integer',
-        format: 'int64',
-      });
-
-      const validations = getValidationsFromSchema(node);
-      const wrapper = render(<Validations validations={validations} />).container;
-
-      expect(wrapper).toHaveTextContent('');
-    });
   });
 });


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
[STOP-231](https://smartbear.atlassian.net/browse/STOP-231)

## Description
<!-- Describe your technical changes in detail. -->
Previously range was getting displayed without being defined in the schema for int64.

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Did you test the changes locally, in a PR environment, or somewhere else? -->
<!-- Were unit/integration/e2e/other tests added? If not, why? -->
<!-- Also describe how one or more persons giving a code review can verify your changes. -->
Tested locally by doing yalc in Platform internal.

## Screenshot(s)/recordings(s)
<!-- If applicable, add screenshots or gifs to help demonstrate the changes. -->
<!-- If not applicable, remove this screenshots section before creating the PR. -->
Before
<img width="1387" alt="image" src="https://github.com/user-attachments/assets/5b1d38c3-2575-492b-8285-19f748a036ad">

After 
<img width="1383" alt="image" src="https://github.com/user-attachments/assets/9426860b-bb1b-45ec-a44f-4176ea12e844">

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] This PR's code follows as closely as possible [the coding style/guidelines of this project](???).
- [ ] I have added error reporting and followed [the error reporting guidelines](???).
- [ ] I have added event tracking and followed [the event tracking guidelines](???).
- [ ] I have updated any relevant documentation accordingly to reflect this PR's changes.
- [ ] I have added automated tests (unit/integration/e2e/other) to cover my changes.
- [x] All new and existing tests pass locally (excluding flaky CI tests).
<!-- It's up to the discretion of the code reviewer(s) whether or not all of these must be checked before approval. -->


[STOP-231]: https://smartbear.atlassian.net/browse/STOP-231?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ