### PR TITLE
fix: migrate jotai functions to useSetAtom and useAtomValue

### DIFF
--- a/src/components/JsonSchemaViewer.tsx
+++ b/src/components/JsonSchemaViewer.tsx
@@ -7,8 +7,7 @@ import {
 import { Box, Provider as MosaicProvider } from '@stoplight/mosaic';
 import { ErrorBoundaryForwardedProps, FallbackProps, withErrorBoundary } from '@stoplight/react-error-boundary';
 import cn from 'classnames';
-import { Provider } from 'jotai';
-import { useUpdateAtom } from 'jotai/utils';
+import { Provider, useSetAtom } from 'jotai';
 import * as React from 'react';
 
 import { JSVOptions, JSVOptionsContextProvider } from '../contexts';
@@ -104,7 +103,7 @@ const JsonSchemaViewerInner = ({
   | 'parentCrumbs'
   | 'skipTopLevelDescription'
 >) => {
-  const setHoveredNode = useUpdateAtom(hoveredNodeAtom);
+  const setHoveredNode = useSetAtom(hoveredNodeAtom);
   const onMouseLeave = React.useCallback(() => {
     setHoveredNode(null);
   }, [setHoveredNode]);

--- a/src/components/SchemaRow/SchemaRow.tsx
+++ b/src/components/SchemaRow/SchemaRow.tsx
@@ -1,8 +1,7 @@
 import { isMirroredNode, isReferenceNode, isRegularNode, SchemaNode } from '@stoplight/json-schema-tree';
 import { Box, Flex, NodeAnnotation, Select, SpaceVals, VStack } from '@stoplight/mosaic';
 import type { ChangeType } from '@stoplight/types';
-import { Atom } from 'jotai';
-import { useAtomValue, useUpdateAtom } from 'jotai/utils';
+import { Atom, useAtomValue, useSetAtom } from 'jotai';
 import last from 'lodash/last.js';
 import * as React from 'react';
 
@@ -39,7 +38,7 @@ export const SchemaRow: React.FunctionComponent<SchemaRowProps> = React.memo(
       viewMode,
     } = useJSVOptionsContext();
 
-    const setHoveredNode = useUpdateAtom(hoveredNodeAtom);
+    const setHoveredNode = useSetAtom(hoveredNodeAtom);
 
     const nodeId = getNodeId(schemaNode, parentNodeId);
 

--- a/src/components/SchemaRow/TopLevelSchemaRow.tsx
+++ b/src/components/SchemaRow/TopLevelSchemaRow.tsx
@@ -1,7 +1,7 @@
 import { isPlainObject } from '@stoplight/json';
 import { isRegularNode, RegularNode } from '@stoplight/json-schema-tree';
 import { Box, Flex, HStack, Icon, Menu, Pressable } from '@stoplight/mosaic';
-import { useUpdateAtom } from 'jotai/utils';
+import { useSetAtom } from 'jotai';
 import { isEmpty } from 'lodash';
 import * as React from 'react';
 
@@ -152,7 +152,7 @@ function ScrollCheck() {
   const elementRef = React.useRef<HTMLDivElement>(null);
 
   const isOnScreen = useIsOnScreen(elementRef);
-  const setShowPathCrumbs = useUpdateAtom(showPathCrumbsAtom);
+  const setShowPathCrumbs = useSetAtom(showPathCrumbsAtom);
   React.useEffect(() => {
     setShowPathCrumbs(!isOnScreen);
   }, [isOnScreen, setShowPathCrumbs]);


### PR DESCRIPTION
Hi, there!! Hope this isn't an unwelcome contribution.

The jotai functions currently display deprecation notices surrounding the use of several functions, especially those from `jotai/utils`.

fix #259

## Motivation and Context

We use the `@MetaMask/open-rpc-docs-react` package for our Docusaurus site. Every time we build, there are many deprecation notices, just like is mentioned in issue #259. I've experimented with locally applying a patch to the package once downloaded, and the deprecation warnings disappear. This PR is a more "proper" form of that fix.

## Description

This change migrates to the newer functions recommended by the deprecation notices. To accomplish this,

- I've removed all imports from `jotai/utils`.
- `useAtomValue` is now imported directly from `jotai` instead
- `useUpdateAtom` (from `jotai/utils`) is replaced by `useSetAtom` from `jotai`.

## How Has This Been Tested?

I've made the same changes to the `node_modules` version of this package in my local Docusaurus site, and the build proceeds with no deprecation notices.

I've also run the `yarn test.prod` script, and all tests pass. The functions I've used to replace the deprecated ones seem like drop-in replacements, and there shouldn't be any trouble. In [this (old) commit](https://github.com/pmndrs/jotai/pull/1631/commits/a217eb52a760ca5c7368c031ba471275223a1933) in the `jotai` package, they're using these same functions "internally" for these deprecated functions I'm replacing.

I'm not sure if it's necessary to add error reporting or more test cases for a change this "simple," but I'm more than happy to add them if it's required.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] This PR's code follows as closely as possible [the coding style/guidelines of this project](???).
- [ ] I have added error reporting and followed [the error reporting guidelines](???).
- [ ] I have added event tracking and followed [the event tracking guidelines](???).
- [ ] I have updated any relevant documentation accordingly to reflect this PR's changes.
- [ ] I have added automated tests (unit/integration/e2e/other) to cover my changes.
- [x] All new and existing tests pass locally (excluding flaky CI tests).
<!-- It's up to the discretion of the code reviewer(s) whether or not all of these must be checked before approval. -->
